### PR TITLE
Upgrade cats-effect and use .allocated for Leak

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import ReleaseTransformations._
 
 // Library versions all in one place, for convenience and sanity.
 lazy val catsVersion          = "1.4.0"
-lazy val catsEffectVersion    = "1.0.0"
+lazy val catsEffectVersion    = "1.1.0"
 lazy val catsMtlVersion       = "0.3.0"
 lazy val catsTaglessVersion   = "0.1.0"
 lazy val kindProjectorVersion = "0.9.8"

--- a/modules/core/src/main/scala/util/Leak.scala
+++ b/modules/core/src/main/scala/util/Leak.scala
@@ -5,34 +5,14 @@
 package skunk.util
 
 import cats.effect._
-import cats.effect.concurrent._
-import cats.effect.implicits._
 import cats.implicits._
 
 /** A leaked resource and its cleanup program. */
 sealed abstract case class Leak[F[_], A](value: A, release: F[Unit])
 
 object Leak {
-
-  private def chain(t: Throwable): Exception =
-    new RuntimeException("Resource allocation failed. See cause for details.", t)
-
-  def of[F[_], A](rfa: Resource[F, A])(
-    implicit cf: Concurrent[F]
-  ): F[Leak[F, A]] =
-    for {
-      du <- Deferred[F, Unit]
-      mv <- MVar[F].empty[Either[Throwable, A]]
-      _  <- rfa.use {            a => mv.put(Right(a)) *> du.get }
-              .handleErrorWith { e => mv.put(Left(e))  *> du.get }
-              .start
-      e  <- mv.take
-      a  <- e match {
-              case Right(a) => cf.pure(new Leak(a, du.complete(())) {})
-              case Left(e)  => cf.raiseError(chain(e))
-            }
-    } yield a
-
+  def of[F[_]: Bracket[?[_], Throwable], A](rfa: Resource[F, A]): F[Leak[F, A]] =
+    rfa.allocated.map(t => new Leak(t._1, t._2) {})
 }
 
 


### PR DESCRIPTION
This PR upgrades the `cats-effect` to `1.1.0`. 

With that, we gain the new method `allocated` for a `Resource`, which is essentially what `Leak` attempted to do. I changed `Leaks` construction to now use this method. I decided to leave `Leak` as a type here because it seems more expressive than just a normal tuple. Let me know if you'd prefer that handled another way 😄 

Fixes #2 