### PR TITLE
warnings

### DIFF
--- a/modules/core/src/main/scala/exception/ProtocolError.scala
+++ b/modules/core/src/main/scala/exception/ProtocolError.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2018 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.exception
+
+import cats.implicits._
+import skunk.net.message.BackendMessage
+import skunk.util.Origin
+import skunk.util.Pretty
+
+class ProtocolError protected[skunk](
+  val message:  BackendMessage,
+  val origin:   Origin
+) extends Error(s"Unexpected backend message: $message") with scala.util.control.NoStackTrace {
+
+  protected def title: String =
+    s"An unhandled backend message was encountered\n  at $origin"
+
+  protected def width = 80 // wrap here
+
+  def labeled(label: String, s: String): String =
+    if (s.isEmpty) "" else {
+      "\n|" +
+      label + Console.CYAN + Pretty.wrap(
+        width - label.length,
+        s,
+        s"${Console.RESET}\n${Console.CYAN}" + label.map(_ => ' ')
+      ) + Console.RESET
+    }
+
+  final protected def header: String =
+    s"""|$title
+        |${labeled("  Message: ", message.toString())}
+        |
+        |This is an ${Console.UNDERLINED}implementation error${Console.RESET} in Skunk.
+        |Please report a bug with the full contents of this error message.
+        |""".stripMargin
+
+  protected def sections: List[String] =
+    List(header) //, exchanges)
+
+  final override def toString =
+    sections
+      .combineAll
+      .lines
+      .map("🔥  " + _)
+      .mkString("\n", "\n", s"\n\n${getClass.getName}: $message")
+
+}
+

--- a/modules/core/src/main/scala/net/AbstractMessageSocket.scala
+++ b/modules/core/src/main/scala/net/AbstractMessageSocket.scala
@@ -1,0 +1,21 @@
+package skunk.net
+
+import skunk.net.message.BackendMessage
+import skunk.util.Origin
+import cats.effect.Concurrent
+import cats.implicits._
+import skunk.exception.ProtocolError
+
+abstract class AbstractMessageSocket[F[_]: Concurrent]
+  extends MessageSocket[F] {
+
+    def expect[B](f: PartialFunction[BackendMessage, B])(implicit or: Origin): F[B] =
+      receive.flatMap { m =>
+        if (f.isDefinedAt(m)) f(m).pure[F]
+        else Concurrent[F].raiseError(new ProtocolError(m, or))
+      }
+
+    def flatExpect[B](f: PartialFunction[BackendMessage, F[B]])(implicit or: Origin): F[B] =
+      expect(f).flatten
+
+  }

--- a/modules/core/src/main/scala/net/protocol/package.scala
+++ b/modules/core/src/main/scala/net/protocol/package.scala
@@ -8,6 +8,7 @@ import skunk.net.message._
 import skunk.util.Namer
 
 package object protocol {
+import skunk.util.Origin
 
   def exchange[F[_], A](fa: F[A])(
     implicit exchange: Exchange[F]
@@ -22,10 +23,16 @@ package object protocol {
   def history[F[_]](max: Int)(implicit ev: MessageSocket[F]): F[List[Either[Any, Any]]] =
     ev.history(max)
 
-  def expect[F[_], B](f: PartialFunction[BackendMessage, B])(implicit ev: MessageSocket[F]): F[B] =
+  def expect[F[_], B](f: PartialFunction[BackendMessage, B])(
+    implicit ev: MessageSocket[F],
+             or: Origin
+  ): F[B] =
     ev.expect(f)
 
-  def flatExpect[F[_], B](f: PartialFunction[BackendMessage, F[B]])(implicit ev: MessageSocket[F]): F[B] =
+  def flatExpect[F[_], B](f: PartialFunction[BackendMessage, F[B]])(
+    implicit ev: MessageSocket[F],
+             or: Origin
+  ): F[B] =
     ev.flatExpect(f)
 
   def nextName[F[_]](prefix: String)(implicit ev: Namer[F]): F[String] =

--- a/modules/tests/src/main/scala/ffstest/FFramework.scala
+++ b/modules/tests/src/main/scala/ffstest/FFramework.scala
@@ -4,6 +4,7 @@
 
 package ffstest
 
+import cats.Eq
 import cats.effect._
 import cats.implicits._
 import sbt.testing.{ Framework, _ }
@@ -19,6 +20,11 @@ trait FTest {
   def fail[A](msg: String): IO[A] = IO.raiseError(new AssertionError(msg))
   def fail[A](msg: String, cause: Throwable): IO[A] = IO.raiseError(new AssertionError(msg, cause))
   def assert(msg: => String, b: => Boolean): IO[Unit] = if (b) IO.pure(()) else fail(msg)
+
+  def assertEqual[A: Eq](msg: => String, actual: A, expected: A): IO[Unit] =
+    if (expected === actual) IO.pure(())
+    else fail(msg + s"\n  expected: $expected\n   actual: $actual")
+
 }
 
 class FFramework extends Framework {

--- a/modules/tests/src/test/scala/SkunkTest.scala
+++ b/modules/tests/src/test/scala/SkunkTest.scala
@@ -20,6 +20,7 @@ trait SkunkTest extends ffstest.FTest {
       port     = 5432,
       user     = "postgres",
       database = "world",
+      // debug = true
     )
 
   def sessionTest[A](name: String)(fa: Session[IO] => IO[A]): Unit =
@@ -40,13 +41,13 @@ trait SkunkTest extends ffstest.FTest {
   }
 
   implicit class SkunkTestIOOps[A](fa: IO[A]) {
-    def assertFailsWith[E: ClassTag]: IO[E] =
+    def assertFailsWith[E: ClassTag]: IO[E] = assertFailsWith[E](false)
+    def assertFailsWith[E: ClassTag](show: Boolean): IO[E] =
       fa.attempt.flatMap {
-        case Left(e: E) => e.pure[IO]
+        case Left(e: E) => IO(e.printStackTrace()).whenA(show) *> e.pure[IO]
         case Left(e)    => IO.raiseError(e)
         case Right(a)   => fail[E](s"Expected SqlException, got $a")
       }
   }
-
 
 }


### PR DESCRIPTION
This adds a fatal `ProtocolError` for unhandled messages and removes the handler that swallows warnings, in favor of promoting them to `PostgresErrorException` in the protocol error. I handled a couple cases but many more will come up as we build out the test suite. Also improved the dumb test framework a little bit.