### PR TITLE
initial transaction support

### DIFF
--- a/modules/core/src/main/scala/Transaction.scala
+++ b/modules/core/src/main/scala/Transaction.scala
@@ -1,26 +1,58 @@
+// Copyright (c) 2018 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
 package skunk
 
 import cats._
 import cats.effect.Resource
 import cats.effect.ExitCase
+import cats.effect.ExitCase._
 import cats.implicits._
-import skunk.data.Identifier
 import skunk.implicits._
 import skunk.data.Completion
 import skunk.data.TransactionStatus._
 import skunk.util.Origin
 import skunk.util.CallSite
+import skunk.exception.SkunkException
+import skunk.util.Namer
+import skunk.data.TransactionStatus
 
-
-// Need exceptions for TransctionAlreadyInProgress and NoCurrentTransaction
-
+/**
+ * Control methods for use within a `transaction` block. An instance is provided when you call
+ * `Session.transaction(...).use`.
+ * @see Session#transaction for information on default commit/rollback behavior
+ */
 trait Transaction[F[_]] {
 
+  /** Existential type for savepoints within this transaction block. */
   type Savepoint
 
-  def savepoint(name: Identifier)(implicit o: Origin): F[Savepoint]
+  /**
+   * Current transaction status. It is not usually necessary to check because transactions will be
+   * commited or rolled back automatically, but if your are committing manually and you logic is
+   * sufficiently complex it may be helpful.
+   */
+  def status: F[TransactionStatus]
+
+  /** Create a `Savepoint`, to which you can later roll back. */
+  def savepoint(implicit o: Origin): F[Savepoint]
+
+  /** Roll back to the specified `Savepoint`, leaving the transaction active at that point. */
   def rollback(savepoint: Savepoint)(implicit o: Origin): F[Completion]
+
+  /**
+   * Terminate the transaction by rolling back. This is normally not necessary because a transaction
+   * will be rolled back automatically when the block exits abnormally.
+   * @see Session#transaction for information on default commit/rollback behavior
+   */
   def rollback(implicit o: Origin): F[Completion]
+
+  /**
+   * Terminate the transaction by committing early. This is normally not necessary because a
+   * transaction will be committed automatically if the block exits successfully.
+   * @see Session#transaction for information on default commit/rollback behavior
+   */
   def commit(implicit o: Origin): F[Completion]
 
 }
@@ -29,47 +61,119 @@ object Transaction {
 
   def fromSession[F[_]: MonadError[?[_], Throwable]](
     s: Session[F],
+    n: Namer[F]
+    // o: Origin // origin of the call to .begin
     // also need to take an isolation level
   ): Resource[F, Transaction[F]] = {
 
-    def assertIdle(cs: CallSite): F[Unit] = ???
+    def assertIdle(cs: CallSite): F[Unit] =
+      s.transactionStatus.get.flatMap {
+        case Idle              => ().pure[F]
+        case Active =>
+          new SkunkException(
+            sql      = None,
+            message  = "Nested transactions are not allowed.",
+            hint     = Some("You must roll back or commit the current transaction before starting a new one."),
+            callSite = Some(cs)
+          ).raiseError[F, Unit]
+        case Failed =>
+          new SkunkException(
+            sql      = None,
+            message  = "Nested transactions are not allowed.",
+            hint     = Some("You must roll back the current (failed) transaction before starting a new one."),
+            callSite = Some(cs)
+          ).raiseError[F, Unit]
+      }
 
-    def assertActive(cs: CallSite): F[Unit] = ???
+    def assertActive(cs: CallSite): F[Unit] =
+      s.transactionStatus.get.flatMap {
+        case Idle   =>
+          new SkunkException(
+            sql      = None,
+            message  = "No transaction.",
+            hint     = Some("The transaction has already been committed or rolled back."),
+            callSite = Some(cs)
+          ).raiseError[F, Unit]
+        case Active => ().pure[F]
+        case Failed =>
+          new SkunkException(
+            sql      = None,
+            message  = "Transaction has failed.",
+            hint     = Some("""
+              |The active transaction has failed and needs to be rolled back (either entirely or to
+              |a prior savepoint) before you can continue. The most common explanation is that
+              |Postgres raised an error earlier in the transaction and you handled it in your
+              |application code, but you forgot to roll back.
+            """.trim.stripMargin.replace('\n', ' ')),
+            callSite = Some(cs)
+          ).raiseError[F, Unit]
+      }
+
+    def assertActiveOrError(cs: CallSite): F[Unit] =
+      cs.pure[F].void
+
+    def doRollback: F[Completion] =
+      s.execute(internal"ROLLBACK".command)
+
+    def doCommit: F[Completion] =
+      s.execute(internal"COMMIT".command)
 
     val acquire: F[Transaction[F]] =
-      assertIdle(CallSite("Transaction.use", Origin.unknown)) *> // this is lame
-      s.execute(sql"BEGIN".command).map { _ =>
+      assertIdle(CallSite("begin", Origin.unknown)) *>
+      s.execute(internal"BEGIN".command).map { _ =>
         new Transaction[F] {
-          type Savepoint = Identifier
 
-          // TODO: check status for all of these
+          type Savepoint = String
+
+          def status: F[TransactionStatus] =
+            s.transactionStatus.get
+
           def commit(implicit o: Origin): F[Completion] =
-            assertActive(o.toCallSite("commit")) *> s.execute(sql"COMMIT".command)
+            assertActive(o.toCallSite("commit")) *>
+            doCommit
 
           def rollback(implicit o: Origin): F[Completion] =
-            assertActive(o.toCallSite("rollback")) *> s.execute(sql"ROLLBACK".command)
+            assertActiveOrError(o.toCallSite("rollback")) *>
+            doRollback
 
           def rollback(savepoint: Savepoint)(implicit o: Origin): F[Completion] =
-            assertActive(o.toCallSite("savepoint")) *> s.execute(sql"ROLLBACK #${savepoint.value}".command)
+            assertActiveOrError(o.toCallSite("savepoint")) *>
+            s.execute(internal"ROLLBACK TO ${savepoint}".command)
 
-          def savepoint(name: Identifier)(implicit o: Origin): F[Savepoint] =
-            assertActive(o.toCallSite("savepoint")) *> s.execute(sql"SAVEPOINT #${name.value}".command).as(name)
+          def savepoint(implicit o: Origin): F[Savepoint] =
+            for {
+              _ <- assertActive(o.toCallSite("savepoint"))
+              i <- n.nextName("savepoint")
+              _ <- s.execute(internal"SAVEPOINT $i".command)
+            } yield i
 
         }
       }
 
-
-    val release: (Transaction[F], ExitCase[Throwable]) => F[Unit] = (xa, ec) =>
+    val release: (Transaction[F], ExitCase[Throwable]) => F[Unit] = (_, ec) =>
       s.transactionStatus.get.flatMap {
-        case Idle              => ().pure[F]
-        case FailedTransaction => s.execute(sql"ROLLBACK".command).void
-        case ActiveTransaction =>
-          (xa, ec) match {
-            case (_, ExitCase.Canceled)  => s.execute(sql"ROLLBACK".command).void
-            case (_, ExitCase.Completed) => s.execute(sql"COMMIT".command).void
-            case (_, ExitCase.Error(t))  => s.execute(sql"ROLLBACK".command) *> t.raiseError[F, Unit]
+        case Idle              =>
+          // This means the user committed manually, so there's nothing to do
+          ().pure[F]
+        case Failed =>
+          ec match {
+            // This is the normal failure case
+            case Error(t)  => doRollback *> t.raiseError[F, Unit]
+            // This is possible if you swallow an error
+            case Completed => doRollback.void
+            // This is possible if you swallow an error and the someone cancels the fiber
+            case Canceled  => doRollback.void
           }
-    }
+        case Active =>
+          ec match {
+            // This is the normal success case
+            case Completed => doCommit.void
+            // If someone cancels the fiber we roll back
+            case Canceled  => doRollback.void
+            // If an error escapes we roll back
+            case Error(t)  => doRollback *> t.raiseError[F, Unit]
+          }
+      }
 
     Resource.makeCase(acquire)(release)
 

--- a/modules/core/src/main/scala/Transaction.scala
+++ b/modules/core/src/main/scala/Transaction.scala
@@ -1,0 +1,55 @@
+package skunk
+
+import cats._
+import cats.effect.Resource
+import cats.effect.ExitCase
+import cats.implicits._
+import skunk.data.Identifier
+import skunk.implicits._
+import skunk.data.Completion
+
+trait Transaction[F[_]] {
+
+  type Savepoint
+
+  def savepoint(name: Identifier): F[Savepoint]
+  def rollback(savepoint: Savepoint): F[Completion]
+  def rollback: F[Completion]
+  def commit: F[Completion]
+
+}
+
+object Transaction {
+
+  def fromSession[F[_]: MonadError[?[_], Throwable]](
+    s: Session[F],
+    // also need to take an isolation level
+  ): Resource[F, Transaction[F]] = {
+
+    val acquire: F[Transaction[F]] =
+      // we're not checking transaction status here because PG errors should be sufficient but we'll
+      // need to write some tests to be sure
+      s.execute(sql"BEGIN".command).map { _ =>
+        new Transaction[F] {
+          type Savepoint = Identifier
+          def commit: F[Completion] = s.execute(sql"COMMIT".command)
+          def rollback: F[Completion] = s.execute(sql"ROLLBACK".command)
+          def rollback(savepoint: Savepoint): F[Completion] = s.execute(sql"ROLLBACK #${savepoint.value}".command)
+          def savepoint(name: Identifier): F[Savepoint] = s.execute(sql"SAVEPOINT #${name.value}".command).as(name)
+        }
+      }
+
+    val release: (Transaction[F], ExitCase[Throwable]) => F[Unit] = {
+      // similarly we're not checking transaction status here either. will need to write tests and
+      // see how this works out.
+      case (_, ExitCase.Canceled)  => s.execute(sql"ROLLBACK".command).void
+      case (_, ExitCase.Completed) => s.execute(sql"COMMIT".command).void
+      case (_, ExitCase.Error(t))  => s.execute(sql"ROLLBACK".command) *> t.raiseError[F, Unit]
+    }
+
+    Resource.makeCase(acquire)(release)
+
+  }
+
+}
+

--- a/modules/core/src/main/scala/data/Completion.scala
+++ b/modules/core/src/main/scala/data/Completion.scala
@@ -15,5 +15,6 @@ object Completion {
   case object Begin              extends Completion
   case object Commit             extends Completion
   case object Rollback           extends Completion
+  case object Savepoint          extends Completion
   // more ...
 }

--- a/modules/core/src/main/scala/data/TransactionStatus.scala
+++ b/modules/core/src/main/scala/data/TransactionStatus.scala
@@ -6,12 +6,18 @@ package skunk.data
 
 import cats.Eq
 
+/** Enumerated type of transaction status values. See the companion object for more information. */
 sealed abstract class TransactionStatus extends Product with Serializable
 object TransactionStatus {
 
-  case object Idle              extends TransactionStatus
-  case object ActiveTransaction extends TransactionStatus
-  case object FailedTransaction extends TransactionStatus
+  /** No current transaction. */
+  case object Idle extends TransactionStatus
+
+  /** Transaction is active has not encountered an error. */
+  case object Active extends TransactionStatus
+
+  /** Transaction has encountered an error and must be rolled back. */
+  case object Failed extends TransactionStatus
 
   implicit val eq: Eq[TransactionStatus] =
     Eq.fromUniversalEquals

--- a/modules/core/src/main/scala/exception/ColumnAlignmentException.scala
+++ b/modules/core/src/main/scala/exception/ColumnAlignmentException.scala
@@ -16,7 +16,7 @@ case class ColumnAlignmentException(
   query: Query[_, _],
   rd:    RowDescription
 ) extends SkunkException(
-  sql       = query.sql,
+  sql       = Some(query.sql),
   message   = "Asserted and actual column types differ.",
   hint      = Some("The decoder you provided is incompatible with the output columns for this query. You may need to add or remove columns from the query or your decoder, change their types, or add explicit SQL casts."),
   sqlOrigin = Some(query.origin),

--- a/modules/core/src/main/scala/exception/DecodeException.scala
+++ b/modules/core/src/main/scala/exception/DecodeException.scala
@@ -25,7 +25,7 @@ class DecodeException[F[_], A, B](
   encoder:   Encoder[A],
   rowDescription: RowDescription
 ) extends SkunkException(
-  sql             = sql,
+  sql             = Some(sql),
   message         = "Decoding error.",
   detail          = Some("This query's decoder was unable to decode a row of data."),
   arguments       = encoder.types.zip(encoder.encode(arguments)),

--- a/modules/core/src/main/scala/exception/NoDataException.scala
+++ b/modules/core/src/main/scala/exception/NoDataException.scala
@@ -9,7 +9,7 @@ import skunk.Query
 case class NoDataException(
   query: Query[_, _],
 ) extends SkunkException(
-  sql       = query.sql,
+  sql       = Some(query.sql),
   message   = "Statement does not return data.",
   hint      = Some(s"This ${framed("query")} returns no row. Use a ${framed("command")} instead."),
   sqlOrigin = Some(query.origin),

--- a/modules/core/src/main/scala/exception/PostgresErrorException.scala
+++ b/modules/core/src/main/scala/exception/PostgresErrorException.scala
@@ -18,7 +18,7 @@ class PostgresErrorException private[skunk](
   arguments:       List[(Type, Option[String])] = Nil,
   argumentsOrigin: Option[Origin]               = None
 ) extends SkunkException(
-  sql       = sql,
+  sql       = Some(sql),
   message   = {
     val m = info.getOrElse('M', sys.error("Invalid ErrorInfo: no message"))
     m.take(1).toUpperCase + m.drop(1) + "."

--- a/modules/core/src/main/scala/exception/UnexpectedColumnsException.scala
+++ b/modules/core/src/main/scala/exception/UnexpectedColumnsException.scala
@@ -14,7 +14,7 @@ case class UnexpectedRowsException(
   command: Command[_],
   rd:    RowDescription
 ) extends SkunkException(
-  sql       = command.sql,
+  sql       = Some(command.sql),
   message   = "Statement returns data.",
   hint      = Some(s"This ${framed("command")} returns rows and should be a ${framed("query")}."),
   sqlOrigin = Some(command.origin),

--- a/modules/core/src/main/scala/net/BufferedMessageSocket.scala
+++ b/modules/core/src/main/scala/net/BufferedMessageSocket.scala
@@ -13,7 +13,6 @@ import fs2.concurrent._
 import fs2.Stream
 import skunk.data._
 import skunk.net.message._
-import skunk.util.Origin
 
 /**
  * A `MessageSocket` that buffers incoming messages, removing and handling asynchronous back-end

--- a/modules/core/src/main/scala/net/Protocol.scala
+++ b/modules/core/src/main/scala/net/Protocol.scala
@@ -183,11 +183,11 @@ object Protocol {
   def apply[F[_]: Concurrent: ContextShift](
     host:  String,
     port:  Int,
-    debug: Boolean
+    debug: Boolean,
+    nam:  Namer[F]
   ): Resource[F, Protocol[F]] =
     for {
       bms <- BufferedMessageSocket[F](host, port, 256, debug) // TODO: should we expose the queue size?
-      nam <- Resource.liftF(Namer[F])
       sem <- Resource.liftF(Semaphore[F](1))
     } yield
       new Protocol[F] {

--- a/modules/core/src/main/scala/net/message/CommandComplete.scala
+++ b/modules/core/src/main/scala/net/message/CommandComplete.scala
@@ -46,6 +46,7 @@ object CommandComplete {
     case "SET"              => apply(Completion.Set)
     case "UNLISTEN"         => apply(Completion.Unlisten)
     case "ROLLBACK"         => apply(Completion.Rollback)
+    case "SAVEPOINT"        => apply(Completion.Savepoint)
     case Patterns.Select(s) => apply(Completion.Select(s.toInt))
     // more .. fill in as we hit them
   }

--- a/modules/core/src/main/scala/net/message/ReadyForQuery.scala
+++ b/modules/core/src/main/scala/net/message/ReadyForQuery.scala
@@ -17,8 +17,8 @@ object ReadyForQuery {
   def decoder: Decoder[BackendMessage] =
     byte.map {
       case 'I' => ReadyForQuery(TransactionStatus.Idle)
-      case 'T' => ReadyForQuery(TransactionStatus.ActiveTransaction)
-      case 'E' => ReadyForQuery(TransactionStatus.FailedTransaction)
+      case 'T' => ReadyForQuery(TransactionStatus.Active)
+      case 'E' => ReadyForQuery(TransactionStatus.Failed)
     }
 
 }

--- a/modules/core/src/main/scala/syntax/StringContextOps.scala
+++ b/modules/core/src/main/scala/syntax/StringContextOps.scala
@@ -5,6 +5,7 @@
 package skunk
 package syntax
 
+import cats.implicits._
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 import skunk.data.Identifier
@@ -18,6 +19,11 @@ class StringContextOps private[skunk](sc: StringContext) {
 
   def id(): Identifier =
     macro StringContextOps.StringOpsMacros.identifier_impl
+
+  private[skunk] def internal(literals: String*): Fragment[Void] = {
+    val chunks = sc.parts.zipAll(literals, "", "").flatMap { case (a, b) => List(a.asLeft, b.asLeft) }
+    Fragment(chunks.toList, Void.codec, Origin.unknown)
+  }
 
 }
 

--- a/modules/core/src/main/scala/util/Namer.scala
+++ b/modules/core/src/main/scala/util/Namer.scala
@@ -18,7 +18,7 @@ object Namer {
     Ref[F].of(1).map { ctr =>
       new Namer[F] {
         def nextName(prefix: String) =
-          ctr.modify(n => (n + 1, s"$prefix-$n"))
+          ctr.modify(n => (n + 1, s"${prefix}_$n"))
       }
     }
 

--- a/modules/core/src/main/scala/util/Origin.scala
+++ b/modules/core/src/main/scala/util/Origin.scala
@@ -8,8 +8,13 @@ import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
 final case class Origin(file: String, line: Int) {
+
+  def toCallSite(methodName: String): CallSite =
+    CallSite(methodName, this)
+
   override def toString =
     s"$file:$line"
+
 }
 
 object Origin {

--- a/modules/example/src/main/scala/Transaction.scala
+++ b/modules/example/src/main/scala/Transaction.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2018 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package example
+
+import cats.effect._
+import cats.implicits._
+import skunk._, skunk.implicits._, skunk.codec.all.int4
+
+object Transaction extends IOApp {
+
+  def session[F[_]: Concurrent: ContextShift]: Resource[F, Session[F]] =
+    Session.single(
+      host     = "localhost",
+      port     = 5432,
+      user     = "postgres",
+      database = "world",
+    )
+
+  def runS[F[_]: Concurrent: ContextShift]: F[_] =
+    session[F].use { s =>
+      s.transaction.use { t =>
+        for {
+          p <- t.savepoint
+          _ <- s.execute(sql"blah".command).attempt
+          _ <- t.rollback(p)
+          n <- s.execute(sql"select 1".query(int4))
+        } yield n
+      }
+    }
+
+  def run(args: List[String]): IO[ExitCode] =
+    runS[IO].attempt.as(ExitCode.Success)
+
+}

--- a/modules/tests/src/test/scala/TransactionStatusTest.scala
+++ b/modules/tests/src/test/scala/TransactionStatusTest.scala
@@ -30,17 +30,17 @@ object TransactionStatusTest extends SkunkTest {
     for {
       _ <- s.assertTransactionStatus("initial state", Idle)
       _ <- s.execute(sql"begin".command)
-      _ <- s.assertTransactionStatus("after begin", ActiveTransaction)
+      _ <- s.assertTransactionStatus("after begin", Active)
       _ <- s.execute(sql"commit".command)
       _ <- s.assertTransactionStatus("after commit", Idle)
       _ <- s.execute(sql"begin".command)
-      _ <- s.assertTransactionStatus("after begin", ActiveTransaction)
+      _ <- s.assertTransactionStatus("after begin", Active)
       _ <- s.execute(sql"rollback".command)
       _ <- s.assertTransactionStatus("after rollback", Idle)
       _ <- s.execute(sql"begin".command)
-      _ <- s.assertTransactionStatus("after begin", ActiveTransaction)
+      _ <- s.assertTransactionStatus("after begin", Active)
       _ <- s.execute(sql"foo?".command).assertFailsWith[PostgresErrorException] // ensure recovery
-      _ <- s.assertTransactionStatus("after error", FailedTransaction)
+      _ <- s.assertTransactionStatus("after error", Failed)
       _ <- s.execute(sql"rollback".command)
       _ <- s.assertTransactionStatus("after rollback", Idle)
     } yield "ok"


### PR DESCRIPTION
This adds a high-level managed transaction as a resource, as an alternative to manually doing `BEGIN` and `COMMIT`.