### PR TITLE
global nio pool

### DIFF
--- a/modules/core/src/main/scala/net/MessageSocket.scala
+++ b/modules/core/src/main/scala/net/MessageSocket.scala
@@ -10,6 +10,8 @@ import fs2.concurrent.InspectableQueue
 import scodec.codecs._
 import skunk.net.message.{ Sync => _, _ }
 import skunk.util.Origin
+import java.nio.channels.AsynchronousChannelGroup
+import scala.concurrent.duration.FiniteDuration
 
 /** A higher-level `BitVectorSocket` that speaks in terms of `Message`. */
 trait MessageSocket[F[_]] {
@@ -73,9 +75,16 @@ object MessageSocket {
       }
     }
 
-  def apply[F[_]: Concurrent: ContextShift](host: String, port: Int, debug: Boolean): Resource[F, MessageSocket[F]] =
+  def apply[F[_]: Concurrent: ContextShift](
+    host: String,
+    port: Int,
+    debug: Boolean,
+    readTimeout:  FiniteDuration,
+    writeTimeout: FiniteDuration,
+    acg:  AsynchronousChannelGroup
+  ): Resource[F, MessageSocket[F]] =
     for {
-      bvs <- BitVectorSocket(host, port)
+      bvs <- BitVectorSocket(host, port, readTimeout, writeTimeout, acg)
       ms  <- Resource.liftF(fromBitVectorSocket(bvs, debug))
     } yield ms
 


### PR DESCRIPTION
This makes the async channel group a parameter and provides a default one because that's usually what you want. It also exposes all the connection params all the way up.