### PR TITLE
fixing encoding of temporal simple codec

### DIFF
--- a/modules/core/src/main/scala/codec/TemporalCodecs.scala
+++ b/modules/core/src/main/scala/codec/TemporalCodecs.scala
@@ -13,14 +13,16 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
+import java.time.temporal.TemporalAccessor
+
 import skunk.data.Type
 
 trait TemporalCodecs {
 
-  private def temporal[A](format: String, parse: (String, DateTimeFormatter) => A, tpe: Type): Codec[A] = {
+  private def temporal[A <: TemporalAccessor](format: String, parse: (String, DateTimeFormatter) => A, tpe: Type): Codec[A] = {
     val fmt = DateTimeFormatter.ofPattern(format)
     Codec.simple(
-      a => format.format(a),
+      a => fmt.format(a),
       s => Either.catchOnly[DateTimeParseException](parse(s, fmt)).leftMap(_.toString),
       tpe
     )


### PR DESCRIPTION
Current encoder for temporal is not working properly
```scala
object Main{
  def main(args: Array[String]): Unit = {
    val date = LocalDateTime.now()
    println(temporal.timestamp(1).encode(date))
  }
}
```
produces folowing
```
List(Some(yyyy-MM-dd HH:mm:ss.S))
```
I saw that there is some fix temporal branch, didn't look too deep into it. I can drop this one, or if this change is ok, i can add some tests for whole encodings