### PR TITLE
Fix a typo in the error message

### DIFF
--- a/modules/core/src/main/scala/exception/PostgresErrorException.scala
+++ b/modules/core/src/main/scala/exception/PostgresErrorException.scala
@@ -149,7 +149,7 @@ class PostgresErrorException private[skunk](
   private def trap: String =
     SqlState.values.find(_.code == code).foldMap { st =>
       s"""|If this is an error you wish to trap and handle in your application, you can do
-          |so with a SqlState extractor .For example:
+          |so with a SqlState extractor. For example:
           |
           |  ${Console.GREEN}doSomething.recoverWith { case SqlState.${st.entryName}(ex) =>  ...}${Console.RESET}
           |


### PR DESCRIPTION
Noticed it in a tweet: https://twitter.com/tpolecat/status/1193216473357017095