### PR TITLE
md5 password authentication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,7 @@ services:
     ports:
       - 5432:5432
     environment:
-      POSTGRES_DB: 'world'
+      POSTGRES_USER: jimmy
+      POSTGRES_PASSWORD: banana
+      POSTGRES_DB: world
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres:9.5
+    image: postgres:11
     volumes:
       - ./world/world.sql:/docker-entrypoint-initdb.d/world.sql
     ports:

--- a/modules/core/src/main/scala/Session.scala
+++ b/modules/core/src/main/scala/Session.scala
@@ -201,6 +201,7 @@ object Session {
     port:         Int            = 5432,
     user:         String,
     database:     String,
+    password:     Option[String] = none,
     max:          Int,
     debug:        Boolean        = false,
     readTimeout:  FiniteDuration = Int.MaxValue.seconds,
@@ -212,7 +213,7 @@ object Session {
       for {
         namer <- Resource.liftF(Namer[F])
         proto <- Protocol[F](host, port, debug, namer, readTimeout, writeTimeout, socketGroup)
-        _     <- Resource.liftF(proto.startup(user, database))
+        _     <- Resource.liftF(proto.startup(user, database, password))
         sess  <- Resource.liftF(fromProtocol(proto, namer, strategy))
       } yield sess
 
@@ -239,19 +240,21 @@ object Session {
    */
   def single[F[_]: Concurrent: ContextShift: Trace](
     host:         String,
-    port:         Int             = 5432,
+    port:         Int            = 5432,
     user:         String,
     database:     String,
-    debug:        Boolean         = false,
-    readTimeout:  FiniteDuration  = Int.MaxValue.seconds,
-    writeTimeout: FiniteDuration  = 5.seconds,
-    strategy:     Typer.Strategy  = Typer.Strategy.BuiltinsOnly
+    password:     Option[String] = none,
+    debug:        Boolean        = false,
+    readTimeout:  FiniteDuration = Int.MaxValue.seconds,
+    writeTimeout: FiniteDuration = 5.seconds,
+    strategy:     Typer.Strategy = Typer.Strategy.BuiltinsOnly
   ): Resource[F, Session[F]] =
     pooled(
       host         = host,
       port         = port,
       user         = user,
       database     = database,
+      password     = password,
       max          = 1,
       debug        = debug,
       readTimeout  = readTimeout,

--- a/modules/core/src/main/scala/net/Protocol.scala
+++ b/modules/core/src/main/scala/net/Protocol.scala
@@ -88,7 +88,7 @@ trait Protocol[F[_]] {
   /**
    * Initiate the session. This must be the first thing you do. This is very basic at the moment.
    */
-  def startup(user: String, database: String): F[Unit]
+  def startup(user: String, database: String, password: Option[String]): F[Unit]
 
   /**
    * Signal representing the current transaction status as reported by `ReadyForQuery`. It's not
@@ -226,8 +226,8 @@ object Protocol {
         override def execute[B](query: Query[Void, B], ty: Typer): F[List[B]] =
           protocol.Query[F].apply(query, ty)
 
-        override def startup(user: String, database: String): F[Unit] =
-          protocol.Startup[F].apply(user, database)
+        override def startup(user: String, database: String, password: Option[String]): F[Unit] =
+          protocol.Startup[F].apply(user, database, password)
 
         override def transactionStatus: Signal[F, TransactionStatus] =
           bms.transactionStatus

--- a/modules/core/src/main/scala/net/message/PasswordMessage.scala
+++ b/modules/core/src/main/scala/net/message/PasswordMessage.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2018 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.net.message
+import java.security.MessageDigest
+
+// import scodec.codecs._
+
+case class PasswordMessage(password: String)
+
+object PasswordMessage {
+
+  implicit val PasswordMessageFrontendMessage: FrontendMessage[PasswordMessage] =
+    FrontendMessage.tagged('p') {
+      utf8z.contramap[PasswordMessage](_.password)
+    }
+
+  // See https://www.postgresql.org/docs/9.6/protocol-flow.html#AEN113418
+  // and https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/util/MD5Digest.java
+  def md5(user: String, password: String, salt: Array[Byte]): PasswordMessage = {
+
+    // Hash with this thing
+    val md = MessageDigest.getInstance("MD5")
+
+    // First round
+    md.update(password.getBytes("UTF-8"))
+    md.update(user.getBytes("UTF-8"))
+    var hex = BigInt(1, md.digest).toString(16)
+    while (hex.length < 32)
+      hex = "0" + hex
+
+    // Second round
+    md.update(hex.getBytes("UTF-8"))
+    md.update(salt)
+    hex = BigInt(1, md.digest).toString(16)
+    while (hex.length < 32)
+      hex = "0" + hex
+
+    // Done
+    PasswordMessage("md5" + hex)
+
+  }
+
+}

--- a/modules/core/src/main/scala/net/protocol/Startup.scala
+++ b/modules/core/src/main/scala/net/protocol/Startup.scala
@@ -10,16 +10,17 @@ import skunk.net.MessageSocket
 import skunk.net.message._
 import skunk.exception.StartupException
 import natchez.Trace
+import skunk.exception.SkunkException
 
 trait Startup[F[_]] {
-  def apply(user: String, database: String): F[Unit]
+  def apply(user: String, database: String, password: Option[String]): F[Unit]
 }
 
 object Startup {
 
   def apply[F[_]: MonadError[?[_], Throwable]: Exchange: MessageSocket: Trace]: Startup[F] =
     new Startup[F] {
-      override def apply(user: String, database: String): F[Unit] =
+      override def apply(user: String, database: String, password: Option[String]): F[Unit] =
         exchange("startup") {
           val sm = StartupMessage(user, database)
           for {
@@ -28,7 +29,10 @@ object Startup {
                    "database" -> database
                  )
             _ <- send(sm)
-            _ <- expect { case AuthenticationOk => }
+            _ <- flatExpect {
+                    case AuthenticationOk                => ().pure[F]
+                    case AuthenticationMD5Password(salt) => authenticationMD5Password[F](sm, password, salt)
+                 }
             _ <- flatExpect {
                    case ReadyForQuery(_) => ().pure[F]
                    case ErrorResponse(info) =>
@@ -38,5 +42,32 @@ object Startup {
           } yield ()
         }
     }
+
+    // already inside an exchange
+    private def authenticationMD5Password[F[_]: MonadError[?[_], Throwable]: Exchange: MessageSocket: Trace](
+      sm:       StartupMessage,
+      password: Option[String],
+      salt:     Array[Byte]
+    ): F[Unit] =
+      password match {
+
+        case Some(pw) =>
+          for {
+            _ <- send(PasswordMessage.md5(sm.user, pw, salt))
+            _ <- flatExpect {
+                   case AuthenticationOk => ().pure[F]
+                   case ErrorResponse(info) => new StartupException(info, sm.properties).raiseError[F, Unit]
+                 }
+          } yield ()
+
+        case None     =>
+          new SkunkException(
+            sql     = None,
+            message = "Password required.",
+            detail  = Some(s"The PostgreSQL server requested a password for '${sm.user}' but none was given."),
+            hint    = Some("Specify a password when constructing your Session or Session pool.")
+          ).raiseError[F, Unit]
+
+      }
 
 }

--- a/modules/docs/src/main/paradox/tutorial/Setup.md
+++ b/modules/docs/src/main/paradox/tutorial/Setup.md
@@ -18,7 +18,7 @@ Create a new project with Skunk as a dependency.
 
 @@dependency[sbt,Maven,Gradle] {
   group="$org$"
-  artifact="$core-name$_2.12"
+  artifact="$core-dep$"
   version="$version$"
 }
 
@@ -31,10 +31,12 @@ Try out this minimal [IOApp](https://typelevel.org/cats-effect/datatypes/ioapp.h
 Let's examine the code above.
 
 - At ① we import the no-op `Tracer`, which allows us to run Skunk programs with execution tracing disabled. We will revisit @ref:[Tracing](Tracing.md) in a later section.
-- At ② we define a [Resource](https://typelevel.org/cats-effect/datatypes/resource.html)  that yields un-pooled @ref:[Session](../reference/Sessions.md) values and ensures that they are closed after use. We specify the host, port, user, and database.
+- At ② we define a [Resource](https://typelevel.org/cats-effect/datatypes/resource.html)  that yields un-pooled @ref:[Session](../reference/Sessions.md) values and ensures that they are closed after use. We specify the host, port, user, database, and password.
 
 @@@ note
-Skunk does not support authenticated (or encrypted) connections yet. You must connect with a user who can log in without a password.
+Skunk currently allows logging in with no password using the `trust` authentication scheme, or logging in with a password using the `md5` authentication scheme. The former and latter schemes are what you get with the official Postgres Docker image, depending on whether you specify `POSTGRES_PASSWORD` or not.
+
+Skunk does not yet support SSL connections.
 @@@
 
 - At ③ we `use` the resource, specifying a block to execute during the `Session`'s lifetime. No matter how the block terminates (success, failure, cancellation) the `Session` will be closed properly.
@@ -50,7 +52,7 @@ The current date is 2019-05-11.
 
 Here are some modifications that will cause runtime failures. Give them a try and see how Skunk responds.
 
-- Try running with an invalid user or database name.
+- Try running with an invalid user, password, or database name.
 - Introduce a typo into the SQL string.
 - Change the decoder from `date` to another type like `timestamp`.
 

--- a/modules/docs/src/main/scala/tutorial/Command.scala
+++ b/modules/docs/src/main/scala/tutorial/Command.scala
@@ -62,8 +62,9 @@ object Command extends IOApp {
   val session: Resource[IO, Session[IO]] =
     Session.single(
       host     = "localhost",
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
+      password = Some("banana")
     )
 
   def run(args: List[String]): IO[ExitCode] =

--- a/modules/docs/src/main/scala/tutorial/Encoding.scala
+++ b/modules/docs/src/main/scala/tutorial/Encoding.scala
@@ -60,8 +60,9 @@ object Encoding extends IOApp {
   val session: Resource[IO, Session[IO]] =
     Session.single(
       host     = "localhost",
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
+      password = Some("banana"),
       debug    = true,
     )
 

--- a/modules/docs/src/main/scala/tutorial/Query.scala
+++ b/modules/docs/src/main/scala/tutorial/Query.scala
@@ -118,8 +118,9 @@ object Query extends IOApp {
   val session: Resource[IO, Session[IO]] =
     Session.single(
       host     = "localhost",
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
+      password = Some("banana")
     )
 
   def run(args: List[String]): IO[ExitCode] =

--- a/modules/docs/src/main/scala/tutorial/Query2.scala
+++ b/modules/docs/src/main/scala/tutorial/Query2.scala
@@ -17,8 +17,9 @@ object QueryExample extends IOApp {
   val session: Resource[IO, Session[IO]] =
     Session.single(
       host     = "localhost",
-      user     = "postgres",
-      database = "world"
+      user     = "jimmy",
+      database = "world",
+      password = Some("banana")
     )
 
   // a data model

--- a/modules/docs/src/main/scala/tutorial/Setup.scala
+++ b/modules/docs/src/main/scala/tutorial/Setup.scala
@@ -17,14 +17,15 @@ object Hello extends IOApp {
     Session.single(                                          // (2)
       host     = "localhost",
       port     = 5432,
-      user     = "postgres",
-      database = "world"
+      user     = "jimmy",
+      database = "world",
+      password = Some("banana"),
     )
 
   def run(args: List[String]): IO[ExitCode] =
     session.use { s =>                                       // (3)
       for {
-        s <- s.unique(sql"select xcurrent_date".query(date)) // (4)
+        s <- s.unique(sql"select current_date".query(date))  // (4)
         _ <- IO(println(s"The current date is $s."))
       } yield ExitCode.Success
     }

--- a/modules/example/src/main/scala/Channel.scala
+++ b/modules/example/src/main/scala/Channel.scala
@@ -16,8 +16,9 @@ object Channel extends IOApp {
     Session.single(
       host     = "localhost",
       port     = 5432,
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
+      password = Some("banana")
     )
 
   def run(args: List[String]): IO[ExitCode] =

--- a/modules/example/src/main/scala/Error.scala
+++ b/modules/example/src/main/scala/Error.scala
@@ -17,7 +17,7 @@ object Error extends IOApp {
     Session.single(
       host     = "localhost",
       port     = 5432,
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
     )
 

--- a/modules/example/src/main/scala/Main.scala
+++ b/modules/example/src/main/scala/Main.scala
@@ -63,8 +63,9 @@ object Main extends IOApp {
     Session.pooled(
       host     = "localhost",
       port     = 5432,
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
+      password = Some("banana"),
       max      = 10,
     )
 

--- a/modules/example/src/main/scala/Math1.scala
+++ b/modules/example/src/main/scala/Math1.scala
@@ -16,8 +16,9 @@ object Math1 extends IOApp {
     Session.single(
       host     = "localhost",
       port     = 5432,
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
+      password = Some("banana")
     )
 
   // An algebra for doing math.

--- a/modules/example/src/main/scala/Math2.scala
+++ b/modules/example/src/main/scala/Math2.scala
@@ -17,8 +17,9 @@ object Math2 extends IOApp {
     Session.single(
       host     = "localhost",
       port     = 5432,
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
+      password = Some("banana")
     )
 
   // An algebra for doing math.

--- a/modules/example/src/main/scala/Minimal1.scala
+++ b/modules/example/src/main/scala/Minimal1.scala
@@ -15,8 +15,9 @@ object Minimal1 extends IOApp {
   val session: Resource[IO, Session[IO]] =
     Session.single(
       host     = "localhost",
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
+      password = Some("banana"),
     )
 
   def run(args: List[String]): IO[ExitCode] =

--- a/modules/example/src/main/scala/Minimal2.scala
+++ b/modules/example/src/main/scala/Minimal2.scala
@@ -22,8 +22,9 @@ object Minimal2 extends IOApp {
     Session.single(
       host     = "localhost",
       port     = 5432,
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
+      password = Some("banana"),
       // debug    = true
     )
 

--- a/modules/example/src/main/scala/Minimal3.scala
+++ b/modules/example/src/main/scala/Minimal3.scala
@@ -19,8 +19,9 @@ object Minimal3 extends IOApp {
     Session.single(
       host     = "localhost",
       port     = 5432,
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
+      password = Some("banana")
     )
 
   case class Country(code: String, name: String, pop: Long)

--- a/modules/example/src/main/scala/Transaction.scala
+++ b/modules/example/src/main/scala/Transaction.scala
@@ -15,8 +15,9 @@ object Transaction extends IOApp {
     Session.single(
       host     = "localhost",
       port     = 5432,
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
+      password = Some("banana"),
     )
 
   def runS[F[_]: Concurrent: ContextShift]: F[_] =
@@ -32,6 +33,6 @@ object Transaction extends IOApp {
     }
 
   def run(args: List[String]): IO[ExitCode] =
-    runS[IO].attempt.as(ExitCode.Success)
+    runS[IO].as(ExitCode.Success)
 
 }

--- a/modules/tests/src/test/scala/SkunkTest.scala
+++ b/modules/tests/src/test/scala/SkunkTest.scala
@@ -19,8 +19,9 @@ abstract class SkunkTest(strategy: Typer.Strategy = Typer.Strategy.BuiltinsOnly)
     Session.single(
       host     = "localhost",
       port     = 5432,
-      user     = "postgres",
+      user     = "jimmy",
       database = "world",
+      password = Some("banana"),
       strategy = strategy
       // debug = true
     )

--- a/modules/tests/src/test/scala/StartupTest.scala
+++ b/modules/tests/src/test/scala/StartupTest.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2018 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package tests
+
+import cats.effect._
+import cats.implicits._
+import skunk._
+import natchez.Trace.Implicits.noop
+import skunk.exception.SkunkException
+import skunk.exception.StartupException
+
+case object StartupTest extends ffstest.FTest {
+
+  def session(user: String, password: Option[String]): Resource[IO, Session[IO]] =
+    Session.single(
+      host     = "localhost",
+      user     = user,
+      database = "world",
+      password = password,
+    )
+
+  test("successful login") {
+    session("jimmy", Some("banana")).use(_ => IO.unit)
+  }
+
+  test("missing password") {
+    for {
+      e <- session("jimmy", None).use(_ => IO.unit).assertFailsWith[SkunkException]
+      _ <- assertEqual("message", e.message, "Password required.")
+    } yield ()
+  }
+
+  test("incorrect user") {
+    for {
+      e <- session("frank", Some("apple")).use(_ => IO.unit).assertFailsWith[StartupException]
+      _ <- assertEqual("code", e.code, "28P01")
+    } yield ()
+  }
+
+  test("incorrect password") {
+    for {
+      e <- session("jimmy", Some("apple")).use(_ => IO.unit).assertFailsWith[StartupException]
+      _ <- assertEqual("code", e.code, "28P01")
+    } yield ()
+  }
+
+}

--- a/world/Dockerfile
+++ b/world/Dockerfile
@@ -1,3 +1,5 @@
 FROM postgres:11
 ENV POSTGRES_DB world
+ENV POSTGRES_USER jimmy
+ENV POSTGRES_PASSWORD banana
 ADD world.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
The `postgres` Docker container sets up MD5 authentication if you define `POSTGRES_PASSWORD` so let's add support for that. It's probably a common case.