### PR TITLE
reorg codec tests

### DIFF
--- a/modules/core/src/main/scala/net/protocol/Unroll.scala
+++ b/modules/core/src/main/scala/net/protocol/Unroll.scala
@@ -67,8 +67,8 @@ private[protocol] class Unroll[F[_]: MonadError[?[_], Throwable]: MessageSocket:
           decoder.decode(0, data) match {
             case Right(a) => a.pure[F]
             case Left(e)  =>
-              // if the portal is suspended we need to sync back up
-              (send(Sync) *> expect { case ReadyForQuery(_) => }).whenA(bool) *>
+              send(Sync).whenA(bool) *> // if the portal is suspended we need to sync back up
+              expect { case ReadyForQuery(_) => } *>
               new DecodeException(
                 data,
                 e,

--- a/modules/core/src/main/scala/net/protocol/Unroll.scala
+++ b/modules/core/src/main/scala/net/protocol/Unroll.scala
@@ -67,8 +67,8 @@ private[protocol] class Unroll[F[_]: MonadError[?[_], Throwable]: MessageSocket:
           decoder.decode(0, data) match {
             case Right(a) => a.pure[F]
             case Left(e)  =>
-              send(Sync).whenA(bool) *> // if we're suspended we need to sync to get back to an ok state
-              expect { case ReadyForQuery(_) => } *>
+              // if the portal is suspended we need to sync back up
+              (send(Sync) *> expect { case ReadyForQuery(_) => }).whenA(bool) *>
               new DecodeException(
                 data,
                 e,

--- a/modules/tests/src/test/scala/SkunkTest.scala
+++ b/modules/tests/src/test/scala/SkunkTest.scala
@@ -22,7 +22,7 @@ abstract class SkunkTest(strategy: Typer.Strategy = Typer.Strategy.BuiltinsOnly)
       user     = "jimmy",
       database = "world",
       password = Some("banana"),
-      strategy = strategy
+      strategy = strategy,
       // debug = true
     )
 

--- a/modules/tests/src/test/scala/SkunkTest.scala
+++ b/modules/tests/src/test/scala/SkunkTest.scala
@@ -13,7 +13,7 @@ import skunk.implicits._
 import skunk.util.Typer
 import natchez.Trace.Implicits.noop
 
-abstract class SkunkTest(strategy: Typer.Strategy = Typer.Strategy.BuiltinsOnly) extends ffstest.FTest {
+abstract class SkunkTest(debug: Boolean = false, strategy: Typer.Strategy = Typer.Strategy.BuiltinsOnly) extends ffstest.FTest {
 
   val session: Resource[IO, Session[IO]] =
     Session.single(
@@ -23,7 +23,7 @@ abstract class SkunkTest(strategy: Typer.Strategy = Typer.Strategy.BuiltinsOnly)
       database = "world",
       password = Some("banana"),
       strategy = strategy,
-      // debug = true
+      debug    = debug
     )
 
   def sessionTest[A](name: String)(fa: Session[IO] => IO[A]): Unit =
@@ -38,7 +38,7 @@ abstract class SkunkTest(strategy: Typer.Strategy = Typer.Strategy.BuiltinsOnly)
       for {
         _ <- assertTransactionStatus("sanity check", TransactionStatus.Idle)
         n <- s.unique(sql"select 'SkunkTest Health Check'::varchar".query(varchar))
-        _ <- assert("sanity check", n === "SkunkTest Health Check")
+        _ <- assert("sanity check", n == "SkunkTest Health Check")
       } yield ()
 
   }

--- a/modules/tests/src/test/scala/codec/BooleanCodecTest.scala
+++ b/modules/tests/src/test/scala/codec/BooleanCodecTest.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2018 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package tests
+package codec
+
+import cats.implicits._
+import skunk.codec.all._
+
+case object BooleanCodecTest extends CodecTest {
+  codecTest(bool)(true, false)
+}
+
+

--- a/modules/tests/src/test/scala/codec/CodecTest.scala
+++ b/modules/tests/src/test/scala/codec/CodecTest.scala
@@ -3,6 +3,7 @@
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
 package tests
+package codec
 
 import cats.Eq
 import cats.implicits._

--- a/modules/tests/src/test/scala/codec/CodecTest.scala
+++ b/modules/tests/src/test/scala/codec/CodecTest.scala
@@ -35,9 +35,9 @@ abstract class CodecTest(strategy: Typer.Strategy = Typer.Strategy.BuiltinsOnly)
     }
 
   // Test a specific special value like NaN where equals doesn't work
-  def specialValueTest[A](name: String, codec: Codec[A])(value: A, isOk: A => Boolean): Unit =
+  def specialValueTest[A](name: String, codec: Codec[A], ascription: Option[String] = None)(value: A, isOk: A => Boolean): Unit =
     sessionTest(s"${codec.types.mkString(",")}") { s =>
-      s.prepare(sql"select $codec".query(codec)).use { ps =>
+      s.prepare(sql"select $codec#${ascription.foldMap("::" + _)}".query(codec)).use { ps =>
         ps.unique(value).flatMap { a =>
           assert(name, isOk(a)).as(name)
         }

--- a/modules/tests/src/test/scala/codec/CodecTest.scala
+++ b/modules/tests/src/test/scala/codec/CodecTest.scala
@@ -14,7 +14,10 @@ import skunk.util.Typer
 import ffstest.FTest
 
 /** Tests that we check if we can round-trip values via codecs. */
-abstract class CodecTest(strategy: Typer.Strategy = Typer.Strategy.BuiltinsOnly) extends SkunkTest(strategy) {
+abstract class CodecTest(
+  debug:    Boolean = false,
+  strategy: Typer.Strategy = Typer.Strategy.BuiltinsOnly
+) extends SkunkTest(debug, strategy) {
 
   def codecTest[A: Eq](codec: Codec[A])(as: A*): Unit =
     sessionTest(s"${codec.types.mkString(", ")}") { s =>

--- a/modules/tests/src/test/scala/codec/CodecTest.scala
+++ b/modules/tests/src/test/scala/codec/CodecTest.scala
@@ -21,7 +21,7 @@ abstract class CodecTest(strategy: Typer.Strategy = Typer.Strategy.BuiltinsOnly)
       // required for parametrized types
       val sqlString = codec.types match {
         case head :: Nil => sql"select $codec::#${head.name}"
-        case _           => sql"select $codec" 
+        case _           => sql"select $codec"
       }
 
       s.prepare(sqlString.query(codec)).use { ps =>

--- a/modules/tests/src/test/scala/codec/EnumCodecTest.scala
+++ b/modules/tests/src/test/scala/codec/EnumCodecTest.scala
@@ -3,6 +3,7 @@
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
 package tests
+package codec
 
 import cats.Eq
 import skunk.codec.enum._

--- a/modules/tests/src/test/scala/codec/EnumCodecTest.scala
+++ b/modules/tests/src/test/scala/codec/EnumCodecTest.scala
@@ -12,7 +12,7 @@ import skunk.util.Typer.Strategy
 import enumeratum._
 import enumeratum.EnumEntry.Lowercase
 
-case object EnumCodecTest extends CodecTest(Strategy.SearchPath) {
+case object EnumCodecTest extends CodecTest(strategy = Strategy.SearchPath) {
 
   // Case 1: enum defined normally
   sealed abstract class Case1(val label: String)

--- a/modules/tests/src/test/scala/codec/JsonCodecTest.scala
+++ b/modules/tests/src/test/scala/codec/JsonCodecTest.scala
@@ -3,6 +3,7 @@
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
 package tests
+package codec
 
 import cats.implicits._
 import io.circe.Json

--- a/modules/tests/src/test/scala/codec/NumericCodecTest.scala
+++ b/modules/tests/src/test/scala/codec/NumericCodecTest.scala
@@ -3,15 +3,13 @@
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
 package tests
+package codec
 
 import cats.implicits._
 import skunk.codec.all._
 
 /** Test that we can round=trip values via codecs. */
 case object NumericCodecTest extends CodecTest {
-
-  // Boolean
-  codecTest(bool)(true, false)
 
   // Integral
   codecTest(int2)(Short.MinValue, -1, 0, 1, Short.MaxValue)

--- a/modules/tests/src/test/scala/codec/TemporalCodecTest.scala
+++ b/modules/tests/src/test/scala/codec/TemporalCodecTest.scala
@@ -3,6 +3,7 @@
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
 package tests
+package codec
 
 import cats.Eq
 import cats.implicits._

--- a/modules/tests/src/test/scala/codec/TextCodecTest.scala
+++ b/modules/tests/src/test/scala/codec/TextCodecTest.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2018 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package tests
+package codec
+
+import cats.implicits._
+import skunk.codec.all._
+import skunk.implicits._
+
+case object TextCodecTest extends CodecTest {
+
+  // varchar
+  codecTest(varchar)("", "a", "ab", "foo", "föf", "🔥 and 🌈", "مرحبا", "שלום", "你好", "'quotes'")
+  codecTest(varchar(3), "varchar(3)".some)("", "a", "ab", "foo", "föf", "🔥 a", "مرح", "שלו", "你好", "'q'")
+  sessionTest("varchar(3) (trimming)") { s =>
+    for {
+      a <- s.unique(sql"select 'abcdef'::varchar(3)".query(varchar(3)))
+      _ <- assertEqual("value should be trimmed to 3 chars", a, "abc")
+    } yield ()
+  }
+
+  // bpchar
+  codecTest(bpchar)("", "a", "ab", "foo", "föf", "🔥 and 🌈", "مرحبا", "שלום", "你好", "'quotes'")
+  codecTest(bpchar(3), "bpchar(3)".some)("   ", "  a", " ab", "foo", "föf", "🔥 a", "مرح", "שלו", " 你好", "'q'")
+  sessionTest("bpchar(3) (trimmimg)") { s =>
+    for {
+      a <- s.unique(sql"select 'abcdef'::bpchar(3)".query(bpchar(3)))
+      _ <- assertEqual("value should be trimmed to 3 chars", a, "abc")
+    } yield ()
+  }
+  sessionTest("bpchar(3) (padding)") { s =>
+    for {
+      a <- s.unique(sql"select 'ab'::bpchar(3)".query(bpchar(3)))
+      _ <- assertEqual("value should be padded to 3 chars", a, "ab ")
+    } yield ()
+  }
+
+}
+
+

--- a/modules/tests/src/test/scala/codec/TextCodecTest.scala
+++ b/modules/tests/src/test/scala/codec/TextCodecTest.scala
@@ -13,7 +13,7 @@ case object TextCodecTest extends CodecTest {
 
   // varchar
   codecTest(varchar)("", "a", "ab", "foo", "föf", "🔥 and 🌈", "مرحبا", "שלום", "你好", "'quotes'")
-  codecTest(varchar(3), "varchar(3)".some)("", "a", "ab", "foo", "föf", "🔥 a", "مرح", "שלו", "你好", "'q'")
+  codecTest(varchar(3))("", "a", "ab", "foo", "föf", "🔥 a", "مرح", "שלו", "你好", "'q'")
   sessionTest("varchar(3) (trimming)") { s =>
     for {
       a <- s.unique(sql"select 'abcdef'::varchar(3)".query(varchar(3)))
@@ -23,7 +23,7 @@ case object TextCodecTest extends CodecTest {
 
   // bpchar
   codecTest(bpchar)("", "a", "ab", "foo", "föf", "🔥 and 🌈", "مرحبا", "שלום", "你好", "'quotes'")
-  codecTest(bpchar(3), "bpchar(3)".some)("   ", "  a", " ab", "foo", "föf", "🔥 a", "مرح", "שלו", " 你好", "'q'")
+  codecTest(bpchar(3))("   ", "  a", " ab", "foo", "föf", "🔥 a", "مرح", "שלו", " 你好", "'q'")
   sessionTest("bpchar(3) (trimmimg)") { s =>
     for {
       a <- s.unique(sql"select 'abcdef'::bpchar(3)".query(bpchar(3)))

--- a/modules/tests/src/test/scala/codec/UuidCodecTest.scala
+++ b/modules/tests/src/test/scala/codec/UuidCodecTest.scala
@@ -3,6 +3,7 @@
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
 package tests
+package codec
 
 import cats.implicits._
 import skunk.codec.all._


### PR DESCRIPTION
This moves codec tests into their own package and adds a test for `TextCodec`. Also pulls boolean out of numeric. Don't know why it was in there.