### PR TITLE
fix pool reset

### DIFF
--- a/modules/core/src/main/scala/util/Pool.scala
+++ b/modules/core/src/main/scala/util/Pool.scala
@@ -7,6 +7,7 @@ package skunk.util
 import cats.effect.Concurrent
 import cats.effect.concurrent.Deferred
 import cats.effect.concurrent.Ref
+import cats.effect.implicits._
 import cats.effect.Resource
 import cats.implicits._
 import skunk.exception.SkunkException
@@ -23,6 +24,20 @@ object Pool {
         |The most common causes of resource leaks are (a) using a pool on a fiber that was neither
         |joined or canceled prior to pool finalization, and (b) using `Resource.allocated` and
         |failing to finalize allocated resources prior to pool finalization.
+      """.stripMargin.trim.linesIterator.mkString(" "))
+    )
+
+  /**
+   * Exception raised to deferrals that remain during pool finalization. This indicates a
+   * programming error, typically misuse of fibers.
+   */
+  object ShutdownException
+    extends SkunkException(
+      sql     = None,
+      message = "The pool is being finalized and no more resources are available.",
+      hint    = Some("""
+        |The most common cause of this exception is using a pool on a fiber that was neither
+        |joined or canceled prior to pool finalization.
       """.stripMargin.trim.linesIterator.mkString(" "))
     )
 
@@ -49,78 +64,66 @@ object Pool {
     // going to matter.
     type State = (
       List[Option[Alloc]],     // deque of alloc slots (filled on the left, empty on the right)
-      List[Deferred[F, Alloc]] // queue of deferrals awaiting allocs
+      List[Deferred[F, Either[Throwable, Alloc]]] // queue of deferrals awaiting allocs
     )
-
-    def raise[B](e: Exception): F[B] =
-      Concurrent[F].raiseError(e)
 
     // We can construct a pool given a Ref containing our initial state.
     def poolImpl(ref: Ref[F, State]): Resource[F, A] = {
 
       // To give out an alloc we create a deferral first, which we will need if there are no slots
       // available. If there is a filled slot, remove it and yield its alloc. If there is an empty
-      // slot, remove it and allocate (error here is raised to the user). If there are no slots,
-      // enqueue the deferral and wait on it, which will [semantically] block the caller until an
-      // alloc is returned to the pool.
+      // slot, remove it and allocate. If there are no slots, enqueue the deferral and wait on it,
+      // which will [semantically] block the caller until an alloc is returned to the pool.
       val give: F[Alloc] =
-        Deferred[F, Alloc].flatMap { d =>
+        Deferred[F, Either[Throwable, Alloc]].flatMap { d =>
+
+          // If allocation fails for any reason then there's no resource to return to the pool
+          // later, so in this case we have to append a new empty slot to the queue. We do this in
+          // a couple places here so we factored it out.
+          val restore: PartialFunction[Throwable, F[Unit]] = {
+            case _ => ref.update { case (os, ds) => (os :+ None, ds) }
+          }
+
+          // Here we go. The cases are a full slot (done), an empty slot (alloc), and no slots at
+          // all (defer and wait).
           ref.modify {
-
-            // OK I THINK WHAT WE WNAT IS DEFERRED[F, EITHER[THROWABLE, ALLOC]] AND THEN WE RETURN
-            // D.GET.FLATMAP(_.LIFTTO[F]) SO ALLOCATION ERRORS ARE ALWAYS THROWN TO THE AWAITEE ❌❌❌
-
-            case (Nil,           ds) => ((Nil, ds :+ d), d.get)    // enqueue … todo: should we allow a timeout here?
-            case (Some(a) :: os, ds) => ((os, ds), a.pure[F])      // re-use
-            case (None    :: os, ds) => ((os, ds),
-              // Allocate, but if allocation fails put a new None at the end of the queue, otherwise
-              // we will have leaked a slot.
-              rsrc.allocated.onError { case _ =>
-                ref.update { case (os, ds) => (os :+ None, ds) }
-              }
-            )
+            case (Some(a) :: os, ds) => ((os, ds), a.pure[F])
+            case (None    :: os, ds) => ((os, ds), rsrc.allocated.onError(restore))
+            case (Nil,           ds) => ((Nil, ds :+ d), d.get.flatMap(_.liftTo[F].onError(restore)))
           } .flatten
+
         }
 
       // To take back an alloc we nominally just hand it out or push it back onto the queue, but
       // there are a bunch of error conditions to consider. This operation is a finalizer and
       // cannot be canceled, so we don't need to worry about that case here.
       def take(a: Alloc): F[Unit] =
-        reset(a._1).flatMap {
-          // `reset` succeeded, so hand the alloc out to the next waiting deferral if there is one,
-          // otherwise return it to the head of the pool.
-          case true  =>
-            ref.modify {
-              case (os, d :: ds) => ((os, ds), d.complete(a))          // hand it back out
-              case (os, Nil)     => ((Some(a) :: os, Nil), ().pure[F]) // return to pool
-            }
-
-          // `reset` failed, so enqueue a new empty slot and finalize the alloc. If there is a
-          // finalization error it will be raised to the caller.
-          case false =>
-
-            // ... but what about deferrals? hurr .. need to move onError
-            ref.modify {
-              case (os, Nil) =>  ((os :+ None, Nil), a._2)
-              case (os, d :: ds) =>  ((os, ds), a._2 *> // reverse probably
-                rsrc.allocated.flatMap(d.complete).void
-              )
-            }
-
-        } .flatten.onError {
-
-          // `reset` raised an error. Enqueue a new empty slot, finalize the alloc, and re-raise. If
-          // there is an error in finalization it will trump the `reset` error.
-          case t =>
-            ref.modify {
-              case (os, Nil) =>  ((os :+ None, Nil), a._2 *> t.raiseError[F, Unit])
-              case (os, d :: ds) =>  ((os, ds), a._2 *> // reverse probably
-                rsrc.allocated.flatMap(d.complete).void *> t.raiseError[F, Unit]
-              )
-            } .flatten
-
+        reset(a._1).onError {
+          case t     => dispose(a) *> t.raiseError[F, Unit]
+        } flatMap {
+          case true  => recycle(a)
+          case false => dispose(a)
         }
 
+      // Return `a` to the pool. If there are awaiting deferrals, complete the next one. Otherwise
+      // push a filled slot into the queue.
+      def recycle(a: Alloc): F[Unit] =
+        ref.modify {
+          case (os, d :: ds) => ((os, ds), d.complete(a.asRight))  // hand it back out
+          case (os, Nil)     => ((Some(a) :: os, Nil), ().pure[F]) // return to pool
+        } .flatten
+
+      // Something went wrong when returning `a` to the pool so let's dispose of it and figure out
+      // how to clean things up. If there are no deferrals, append an empty slot to take the place
+      // of `a`. If there are deferrals, remove the next one and complete it (failures in allocation
+      // are handled by the awaiting deferral in `give` above). Always finalize `a`
+      def dispose(a: Alloc): F[Unit] =
+        ref.modify {
+          case (os, Nil) =>  ((os :+ None, Nil), ().pure[F]) // new empty slot
+          case (os, d :: ds) =>  ((os, ds), rsrc.allocated.attempt.flatMap(d.complete)) // alloc now!
+        } .guarantee(a._2).flatten
+
+      // Hey, that's all we need to create our resource!
       Resource.make(give)(take).map(_._1)
 
     }
@@ -130,7 +133,8 @@ object Pool {
       Ref[F].of((List.fill(size)(None), Nil))
 
     // When the pool shuts down we finalize all the allocs, which should have been returned by now.
-    // Any remaining deferrals are simply abandoned. Would be nice if we could interrupt them.
+    // Any remaining deferrals (there should be none, but can be due to poor fiber hygeine) are
+    // completed with `ShutdownException`.
     def free(ref: Ref[F, State]): F[Unit] =
       ref.get.flatMap {
 
@@ -138,8 +142,9 @@ object Pool {
         // missing. This would indicate a leak. If there is an error in `free` it will halt
         // finalization of remaining allocs and will be re-raised to the caller, which is a bit
         // harsh. We might want to accumulate failures and raise one big error when we're done.
-        case (os, _) =>
-          raise(ResourceLeak(size, os.length)).whenA(os.length != size) *>
+        case (os, ds) =>
+          ds.traverse(_.complete(Left(ShutdownException))) *>
+          ResourceLeak(size, os.length).raiseError[F, Unit].whenA(os.length != size) *>
           os.traverse_ {
             case Some((_, free)) => free
             case None            => ().pure[F]


### PR DESCRIPTION
This fixes a resource leak in the pool when reset or finalization fail, and ensures that allocation errors always going to the waiting fiber, even if they're provoked by failed cleanup on another fiber. Plus tests for all this.