### PR TITLE
Add `bytea` codec

### DIFF
--- a/modules/core/src/main/scala/codec/AllCodecs.scala
+++ b/modules/core/src/main/scala/codec/AllCodecs.scala
@@ -11,5 +11,6 @@ trait AllCodecs
      with BooleanCodec
      with EnumCodec
      with UuidCodec
+     with BinaryCodecs
 
 object all extends AllCodecs

--- a/modules/core/src/main/scala/codec/BinaryCodecs.scala
+++ b/modules/core/src/main/scala/codec/BinaryCodecs.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk
+package codec
+
+import cats.implicits._
+import scodec.bits.ByteVector
+import skunk.data.Type
+
+trait BinaryCodecs {
+
+  val bytea: Codec[Array[Byte]] = Codec.simple[Array[Byte]](
+    "\\x" + ByteVector.view(_).toHex,
+    z => ByteVector.fromHex(z.substring(2)).map(_.toArray).fold("Cannot decode bytes from HEX String".asLeft[Array[Byte]])(_.asRight[String]),
+    Type.bytea)
+
+}
+
+object binary extends BinaryCodecs

--- a/modules/docs/src/main/paradox/reference/SchemaTypes.md
+++ b/modules/docs/src/main/paradox/reference/SchemaTypes.md
@@ -65,6 +65,16 @@ Skunk codecs have the same names as their corresponding Postgres data types. Def
 - This codec is importable from `skunk.codec.boolean._` or `skunk.codec.all._`.
 - See [§8.6](https://www.postgresql.org/docs/9.1/datatype-boolean.html) in the Postgres documentation for more information on the boolean data type.
 
+## Binary Type
+
+| ANSI SQL Type      | Size                                         | Postgres Type   | Scala Type     |
+|--------------------|----------------------------------------------|-----------------|----------------|
+| `blob`             | 1 or 4 bytes plus the actual binary string   | `bytea`         | `Array[Byte]`  |
+
+#### Notes
+- This codec uses [Hex Format](https://www.postgresql.org/docs/11/datatype-binary.html#id-1.5.7.12.9). Bytea octets in PostgreSQL are output in hex format by default.
+- See [§8.4](https://www.postgresql.org/docs/11/datatype-binary.html) in the Postgres documentation for more information on binary data types.
+
 ## Enumerated Types
 
 Enumerated types are user-defined and are mapped via the `enum` codec constructor, which declares the schema type and defines a mapping to and from string labels. Given the enum declaration:

--- a/modules/tests/src/test/scala/codec/BinaryCodecTest.scala
+++ b/modules/tests/src/test/scala/codec/BinaryCodecTest.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package tests
+package codec
+
+import cats.kernel.Eq
+import skunk.codec.all._
+
+case object BinaryCodecTest extends CodecTest {
+
+  implicit def arrayEq[A]: Eq[Array[A]] = Eq.instance(_.toList == _.toList)
+
+  val byteArray1: Array[Byte] = "someValue".getBytes("UTF-8")
+  val byteArray2: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
+
+  codecTest(bytea)(byteArray1, byteArray2)
+
+}
+
+


### PR DESCRIPTION
This PR brings support for encoding and decoding `Array`s of `Byte`s (BLOBs).