### PR TITLE
add handler for exception thrown in decoder

### DIFF
--- a/modules/core/src/main/scala/Decoder.scala
+++ b/modules/core/src/main/scala/Decoder.scala
@@ -66,7 +66,7 @@ object Decoder {
    * An error indicating that decoding a value starting at column `offset` and spanning `length`
    * columns failed with reason `error`.
    */
-  case class Error(offset: Int, length: Int, message: String)
+  case class Error(offset: Int, length: Int, message: String, cause: Option[Throwable] = None)
 
   implicit val ApplyDecoder: Apply[Decoder] =
     new Apply[Decoder] {

--- a/modules/tests/src/test/scala/issue/Issue129.scala
+++ b/modules/tests/src/test/scala/issue/Issue129.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package tests.issue
+
+import skunk._
+import skunk.codec.all._
+import skunk.implicits._
+import tests.SkunkTest
+import skunk.exception.DecodeException
+import cats.effect.IO
+
+// https://github.com/tpolecat/skunk/issues/129
+case object Issue129Test extends SkunkTest {
+
+  case class Country(name: String, code: String)
+  case class City(name: String, district: String)
+
+  val q: Query[Void, (Country, Option[City])] =
+    sql"""
+      SELECT c.name, c.code, k.name, k.district
+      FROM country c
+      LEFT OUTER JOIN city k
+      ON c.capital = k.id
+      ORDER BY c.code DESC
+    """.query(varchar ~ bpchar(3) ~ varchar.opt ~ varchar.opt)
+       .map {
+          case a ~ b ~ Some(c) ~ Some(d) => (Country(a, b), Some(City(c, d)))
+          // the incomplete match results in a `MatchError` which is expected, but it also
+          // reports a ProtocolError, which shouldn't happen.
+        }
+
+  sessionTest("issue/129") { s =>
+    s.execute(q).assertFailsWith[DecodeException[IO,_,_]](show = true).as("ok")
+  }
+
+}


### PR DESCRIPTION
Fixes  #129 

The problem in the example is that the decoder throws a `MatchError` and we weren't handling it properly. The example now results in an error like this.

<img width="834" alt="image" src="https://user-images.githubusercontent.com/1200131/86492137-bae7f680-bd32-11ea-959d-7f1ff2ed0c79.png">
