### PR TITLE
fix 181 and other discovered issues

### DIFF
--- a/modules/core/src/main/scala/Session.scala
+++ b/modules/core/src/main/scala/Session.scala
@@ -229,7 +229,7 @@ object Session {
    * @param strategy
    * @group Constructors
    */
-  def pooled[F[_]: Concurrent: ContextShift: Trace](
+  def pooled[F[_]: Concurrent: ContextShift: Trace: Timer](
     host:         String,
     port:         Int            = 5432,
     user:         String,
@@ -263,7 +263,7 @@ object Session {
    * single-session pool. This method is shorthand for `Session.pooled(..., max = 1, ...).flatten`.
    * @see pooled
    */
-  def single[F[_]: Concurrent: ContextShift: Trace](
+  def single[F[_]: Concurrent: ContextShift: Trace: Timer](
     host:         String,
     port:         Int            = 5432,
     user:         String,
@@ -290,7 +290,7 @@ object Session {
     ).flatten
 
 
-  def fromSocketGroup[F[_]: Concurrent: ContextShift: Trace](
+  def fromSocketGroup[F[_]: Concurrent: ContextShift: Trace: Timer](
     socketGroup:  SocketGroup,
     host:         String,
     port:         Int            = 5432,

--- a/modules/core/src/main/scala/codec/NumericCodecs.scala
+++ b/modules/core/src/main/scala/codec/NumericCodecs.scala
@@ -19,7 +19,7 @@ trait NumericCodecs {
   val numeric: Codec[BigDecimal] = Codec.simple(_.toString, BigDecimal(_).asRight, Type.numeric)
   def numeric(precision: Int, scale: Int = 0): Codec[BigDecimal] = Codec.simple(_.toString, BigDecimal(_).asRight, Type.numeric(precision, scale))
 
-  val float4: Codec[Double]  = Codec.simple(_.toString, _.toDouble.asRight, Type.float4)
+  val float4: Codec[Float]   = Codec.simple(_.toString, _.toFloat.asRight, Type.float4)
   val float8: Codec[Double]  = Codec.simple(_.toString, _.toDouble.asRight, Type.float8)
 
 }

--- a/modules/core/src/main/scala/data/Completion.scala
+++ b/modules/core/src/main/scala/data/Completion.scala
@@ -30,6 +30,7 @@ object Completion {
   case object DropSchema         extends Completion
   case object CreateType         extends Completion
   case object DropType           extends Completion
+  case object CreateFunction     extends Completion
   // more ...
 
   /**

--- a/modules/core/src/main/scala/net/MessageSocket.scala
+++ b/modules/core/src/main/scala/net/MessageSocket.scala
@@ -31,6 +31,9 @@ trait MessageSocket[F[_]] {
   def expect[B](f: PartialFunction[BackendMessage, B])(implicit or: Origin): F[B]
   def flatExpect[B](f: PartialFunction[BackendMessage, F[B]])(implicit or: Origin): F[B]
 
+  /** Discard any buffered messages and send a `Sync` message. */
+  def sync: F[Unit]
+
 }
 
 object MessageSocket {
@@ -71,6 +74,9 @@ object MessageSocket {
 
         override def history(max: Int): F[List[Either[Any, Any]]] =
           cb.dequeueChunk1(max: Int).map(_.toList)
+
+        def sync: F[Unit] =
+          send(skunk.net.message.Sync)
 
       }
     }

--- a/modules/core/src/main/scala/net/Protocol.scala
+++ b/modules/core/src/main/scala/net/Protocol.scala
@@ -16,6 +16,7 @@ import scala.concurrent.duration.FiniteDuration
 import skunk.util.Typer
 import natchez.Trace
 import fs2.io.tcp.SocketGroup
+import cats.effect.Timer
 
 /**
  * Interface for a Postgres database, expressed through high-level operations that rely on exchange
@@ -183,7 +184,7 @@ object Protocol {
    * @param host  Postgres server host
    * @param port  Postgres port, default 5432
    */
-  def apply[F[_]: Concurrent: ContextShift: Trace](
+  def apply[F[_]: Concurrent: ContextShift: Trace: Timer](
     host:         String,
     port:         Int,
     debug:        Boolean,

--- a/modules/core/src/main/scala/net/message/AuthenticationSASL.scala
+++ b/modules/core/src/main/scala/net/message/AuthenticationSASL.scala
@@ -4,7 +4,7 @@
 
 package skunk.net.message
 
-import scodec.codecs.{ list, cstring }
+import scodec.codecs.list
 
 /**
  * Specifies that SASL authentication is required. The message body is a list of SASL authentication
@@ -15,5 +15,5 @@ final case class AuthenticationSASL(mechanisms: List[String]) extends Authentica
 
 object AuthenticationSASL {
   final val Tagʹ = 10
-  val decoderʹ = list(cstring).map(ss => AuthenticationSASL(ss.init)) // last one is always empty
+  val decoderʹ = list(utf8z).map(ss => AuthenticationSASL(ss.init)) // last one is always empty
 }

--- a/modules/core/src/main/scala/net/message/CommandComplete.scala
+++ b/modules/core/src/main/scala/net/message/CommandComplete.scala
@@ -5,7 +5,6 @@
 package skunk.net.message
 
 import scodec.Decoder
-import scodec.codecs._
 import skunk.data.Completion
 
 import scala.util.matching.Regex
@@ -44,7 +43,7 @@ object CommandComplete {
   }
 
   //TODO: maybe make lazy val
-  def decoder: Decoder[CommandComplete] = cstring.map {
+  def decoder: Decoder[CommandComplete] = utf8z.map {
     case "BEGIN"            => apply(Completion.Begin)
     case "COMMIT"           => apply(Completion.Commit)
     case "CREATE INDEX"     => apply(Completion.CreateIndex)

--- a/modules/core/src/main/scala/net/message/CommandComplete.scala
+++ b/modules/core/src/main/scala/net/message/CommandComplete.scala
@@ -64,6 +64,7 @@ object CommandComplete {
     case "DROP SCHEMA"      => apply(Completion.DropSchema)
     case "CREATE TYPE"      => apply(Completion.CreateType)
     case "DROP TYPE"        => apply(Completion.DropType)
+    case "CREATE FUNCTION"  => apply(Completion.CreateFunction)
     case Patterns.Select(s) => apply(Completion.Select(s.toInt))
     case Patterns.Delete(s) => apply(Completion.Delete(s.toInt))
     case Patterns.Update(s) => apply(Completion.Update(s.toInt))

--- a/modules/core/src/main/scala/net/message/ErrorResponse.scala
+++ b/modules/core/src/main/scala/net/message/ErrorResponse.scala
@@ -26,7 +26,7 @@ object ErrorResponse {
   //          unrecognized type.
   // String - The field value.
   val decoder: Decoder[BackendMessage] =
-    list(cstring).map { ss =>
+    list(utf8z).map { ss =>
       val kv = ss.init.map(s => s.head -> s.tail).toMap // last one is always empty
       ErrorResponse(kv)
     }

--- a/modules/core/src/main/scala/net/message/NoticeResponse.scala
+++ b/modules/core/src/main/scala/net/message/NoticeResponse.scala
@@ -26,7 +26,7 @@ object NoticeResponse {
   //          unrecognized type.
   // String - The field value.
   val decoder: Decoder[BackendMessage] =
-    list(cstring).map { ss =>
+    list(utf8z).map { ss =>
       val kv = ss.init.map(s => s.head -> s.tail).toMap // last one is always empty
       NoticeResponse(kv)
     }

--- a/modules/core/src/main/scala/net/message/NotificationResponse.scala
+++ b/modules/core/src/main/scala/net/message/NotificationResponse.scala
@@ -14,7 +14,7 @@ object NotificationResponse {
   final val Tag = 'A'
 
   val decoder: Decoder[NotificationResponse] =
-    (int32 ~ identifier ~ cstring).map { case pid ~ ch ~ value =>
+    (int32 ~ identifier ~ utf8z).map { case pid ~ ch ~ value =>
       NotificationResponse(Notification(pid, ch, value))
     }
 

--- a/modules/core/src/main/scala/net/message/ParameterStatus.scala
+++ b/modules/core/src/main/scala/net/message/ParameterStatus.scala
@@ -11,5 +11,5 @@ case class ParameterStatus(name: String, value: String) extends BackendMessage
 
 object ParameterStatus {
   final val Tag = 'S'
-  val decoder: Decoder[ParameterStatus] = (cstring ~ cstring).map(apply)
+  val decoder: Decoder[ParameterStatus] = (utf8z ~ utf8z).map(apply)
 }

--- a/modules/core/src/main/scala/net/message/RowDescription.scala
+++ b/modules/core/src/main/scala/net/message/RowDescription.scala
@@ -41,7 +41,7 @@ object RowDescription {
   object Field {
 
     val codec: Codec[Field] =
-      (cstring ~ int32 ~ int16 ~ int32 ~ int16 ~ int32 ~ int16)
+      (utf8z ~ int32 ~ int16 ~ int32 ~ int16 ~ int32 ~ int16)
         .map(apply)
         .decodeOnly
 

--- a/modules/core/src/main/scala/net/message/StartupMessage.scala
+++ b/modules/core/src/main/scala/net/message/StartupMessage.scala
@@ -30,7 +30,7 @@ object StartupMessage {
     FrontendMessage.untagged {
 
       def pair(key: String): Codec[String] =
-        cstring.applied(key) ~> cstring
+        utf8z.applied(key) ~> utf8z
 
       val version: Codec[Unit] =
         int32.applied(196608)

--- a/modules/core/src/main/scala/net/message/package.scala
+++ b/modules/core/src/main/scala/net/message/package.scala
@@ -55,7 +55,7 @@ package object message { module =>
   ).withToString("utf8z")
 
   val identifier: SCodec[Identifier] =
-    cstring.exmap(
+    utf8z.exmap(
       s  => Attempt.fromEither(Identifier.fromString(s).leftMap(Err(_))),
       id => Attempt.successful(id.value)
     )

--- a/modules/core/src/main/scala/net/message/package.scala
+++ b/modules/core/src/main/scala/net/message/package.scala
@@ -11,6 +11,8 @@ import scodec.bits._
 import scodec.codecs._
 import scodec.interop.cats._
 import skunk.data.Identifier
+import scodec.SizeBound
+import scodec.DecodeResult
 
 /**
  * Definitions of Postgres messages, with binary encoders and decoders. Doc for this package isn't
@@ -38,8 +40,19 @@ package object message { module =>
       override def combine(a: Attempt[A], b: Attempt[A]): Attempt[A] = (a, b).mapN(_ |+| _)
     }
 
-  val utf8z: SCodec[String] =
-    (utf8 ~ constant(ByteVector(0))).xmap(_._1, (_, ()))
+  val utf8z: SCodec[String] = filtered(
+    utf8,
+    new SCodec[BitVector] {
+      val nul = BitVector.lowByte
+      override def sizeBound: SizeBound = SizeBound.unknown
+      override def encode(bits: BitVector): Attempt[BitVector] = Attempt.successful(bits ++ nul)
+      override def decode(bits: BitVector): Attempt[DecodeResult[BitVector]] =
+        bits.bytes.indexOfSlice(nul.bytes) match {
+          case -1 => Attempt.failure(Err("Does not contain a 'NUL' termination byte."))
+          case i  => Attempt.successful(DecodeResult(bits.take(i * 8L), bits.drop(i * 8L + 8L)))
+        }
+    }
+  ).withToString("utf8z")
 
   val identifier: SCodec[Identifier] =
     cstring.exmap(

--- a/modules/core/src/main/scala/net/protocol/Bind.scala
+++ b/modules/core/src/main/scala/net/protocol/Bind.scala
@@ -60,7 +60,7 @@ object Bind {
       ): F[Unit] =
         for {
           hi <- history(Int.MaxValue)
-          _  <- send(Sync)
+          _  <- sync
           _  <- expect { case ReadyForQuery(_) => }
           a  <- PostgresErrorException.raiseError[F, Unit](
                   sql             = statement.statement.sql,

--- a/modules/core/src/main/scala/net/protocol/Execute.scala
+++ b/modules/core/src/main/scala/net/protocol/Execute.scala
@@ -52,7 +52,7 @@ object Execute {
       def syncAndFail[A](portal: Protocol.CommandPortal[F, A], info: Map[Char, String]): F[Completion] =
         for {
           hi <- history(Int.MaxValue)
-          _  <- send(Sync)
+          _  <- sync
           _  <- expect { case ReadyForQuery(_) => }
           a  <- new PostgresErrorException(
                   sql             = portal.preparedCommand.command.sql,

--- a/modules/core/src/main/scala/net/protocol/Parse.scala
+++ b/modules/core/src/main/scala/net/protocol/Parse.scala
@@ -60,7 +60,7 @@ object Parse {
       def syncAndFail(statement: Statement[_], info: Map[Char, String]): F[Unit] =
         for {
           hi <- history(Int.MaxValue)
-          _  <- send(Sync)
+          _  <- sync
           _  <- expect { case ReadyForQuery(_) => }
           a  <- new PostgresErrorException(
                   sql       = statement.sql,

--- a/modules/core/src/main/scala/net/protocol/package.scala
+++ b/modules/core/src/main/scala/net/protocol/package.scala
@@ -21,6 +21,9 @@ import skunk.util.Origin
   def send[F[_], A: FrontendMessage](a: A)(implicit ev: MessageSocket[F]): F[Unit] =
     ev.send(a)
 
+  def sync[F[_]](implicit ev: MessageSocket[F]): F[Unit] =
+    ev.sync
+
   def history[F[_]](max: Int)(implicit ev: MessageSocket[F]): F[List[Either[Any, Any]]] =
     ev.history(max)
 

--- a/modules/docs/src/main/paradox/reference/Sessions.md
+++ b/modules/docs/src/main/paradox/reference/Sessions.md
@@ -2,6 +2,7 @@
 import cats.effect._, skunk._, skunk.net.message.StartupMessage
 implicit def dummyContextTrace: ContextShift[IO] = ???
 implicit def dummyTrace: natchez.Trace[IO] = ???
+implicit def dummyTimer: Timer[IO] = ???
 ```
 
 # Sessions

--- a/modules/example/src/main/scala/Error.scala
+++ b/modules/example/src/main/scala/Error.scala
@@ -19,6 +19,7 @@ object Error extends IOApp {
       port     = 5432,
       user     = "jimmy",
       database = "world",
+      password = Some("banana"),
     )
 
   val query =

--- a/modules/example/src/main/scala/Http4s.scala
+++ b/modules/example/src/main/scala/Http4s.scala
@@ -101,7 +101,7 @@ object Http4sExample extends IOApp {
    * Given a `SocketGroup` we can construct a session resource, and from that construct a
    * `Countries` resource.
    */
-  def countriesFromSocketGroup[F[_]: Concurrent: ContextShift: Trace](
+  def countriesFromSocketGroup[F[_]: Concurrent: ContextShift: Trace: Timer](
     socketGroup: SocketGroup
   ): Resource[F, PooledCountries[F]] =
     Session.fromSocketGroup(
@@ -114,7 +114,7 @@ object Http4sExample extends IOApp {
     ).flatMap(countriesFromSession(_))
 
   /** Resource yielding a pool of `Countries`, backed by a single `Blocker` and `SocketGroup`. */
-  def pool[F[_]: Concurrent: ContextShift: Trace]: Resource[F, Resource[F, Countries[F]]] =
+  def pool[F[_]: Concurrent: ContextShift: Trace: Timer]: Resource[F, Resource[F, Countries[F]]] =
     for {
       b  <- Blocker[F]
       sg <- SocketGroup[F](b)
@@ -148,7 +148,7 @@ object Http4sExample extends IOApp {
    * Using `pool` above we can create `HttpRoutes` resource. We also add some standard tracing
    * middleware while we're at it.
    */
-  def routes[F[_]: Concurrent: ContextShift: Trace]: Resource[F, HttpRoutes[F]] =
+  def routes[F[_]: Concurrent: ContextShift: Trace: Timer]: Resource[F, HttpRoutes[F]] =
     pool.map(p => natchezMiddleware(countryRoutes(p)))
 
   /** Our Natchez `EntryPoint` resource. */

--- a/modules/example/src/main/scala/Minimal2.scala
+++ b/modules/example/src/main/scala/Minimal2.scala
@@ -20,7 +20,7 @@ import io.jaegertracing.Configuration.ReporterConfiguration
 
 object Minimal2 extends IOApp {
 
-  def session[F[_]: Concurrent: ContextShift: Trace]: Resource[F, Session[F]] =
+  def session[F[_]: Concurrent: ContextShift: Trace: Timer]: Resource[F, Session[F]] =
     Session.single(
       host     = "localhost",
       port     = 5432,
@@ -51,7 +51,7 @@ object Minimal2 extends IOApp {
       }
     }
 
-  def runF[F[_]: Concurrent: ContextShift: Trace: Parallel]: F[ExitCode] =
+  def runF[F[_]: Concurrent: ContextShift: Trace: Parallel: Timer]: F[ExitCode] =
     session.use { s =>
       List("A%", "B%").parTraverse(p => lookup(p, s))
     } as ExitCode.Success

--- a/modules/example/src/main/scala/Transaction.scala
+++ b/modules/example/src/main/scala/Transaction.scala
@@ -11,7 +11,7 @@ import natchez.Trace.Implicits.noop
 
 object Transaction extends IOApp {
 
-  def session[F[_]: Concurrent: ContextShift]: Resource[F, Session[F]] =
+  def session[F[_]: Concurrent: ContextShift: Timer]: Resource[F, Session[F]] =
     Session.single(
       host     = "localhost",
       port     = 5432,
@@ -20,7 +20,7 @@ object Transaction extends IOApp {
       password = Some("banana"),
     )
 
-  def runS[F[_]: Concurrent: ContextShift]: F[_] =
+  def runS[F[_]: Concurrent: ContextShift: Timer]: F[_] =
     session[F].use { s =>
       s.transaction.use { t =>
         for {

--- a/modules/tests/src/test/scala/QuickQueryErrorTest.scala
+++ b/modules/tests/src/test/scala/QuickQueryErrorTest.scala
@@ -109,8 +109,8 @@ case object QuickQueryErrorTest extends SkunkTest {
 
   sessionTest("not a query, with warning") { s =>
     for {
-      e <- s.execute(sql"commit".query(int4)).assertFailsWith[PostgresErrorException]
-      _ <- assertEqual("message", e.message, "There is no transaction in progress.")
+      e <- s.execute(sql"commit".query(int4)).assertFailsWith[NoDataException]
+      _ <- assertEqual("message", e.message, "Statement does not return data.")
       _ <- s.assertHealthy
     } yield "ok"
   }

--- a/modules/tests/src/test/scala/codec/CodecTest.scala
+++ b/modules/tests/src/test/scala/codec/CodecTest.scala
@@ -51,7 +51,7 @@ abstract class CodecTest(
 
 case object CodecTest extends FTest {
 
-  val c = int2 ~ (int4 ~ float4) ~ varchar
+  val c = int2 ~ (int4 ~ float8) ~ varchar
 
   test("composed codec generates correct sql") {
     assertEqual("sql", c.sql.runA(1).value, "$1, $2, $3, $4")

--- a/modules/tests/src/test/scala/issue/129.scala
+++ b/modules/tests/src/test/scala/issue/129.scala
@@ -2,10 +2,6 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-// Copyright (c) 2018-2020 by Rob Norris
-// This software is licensed under the MIT License (MIT).
-// For more information see LICENSE or https://opensource.org/licenses/MIT
-
 package tests.issue
 
 import skunk._
@@ -16,7 +12,7 @@ import skunk.exception.DecodeException
 import cats.effect.IO
 
 // https://github.com/tpolecat/skunk/issues/129
-case object Issue129Test extends SkunkTest {
+case object Test129 extends SkunkTest {
 
   case class Country(name: String, code: String)
   case class City(name: String, district: String)

--- a/modules/tests/src/test/scala/issue/181.scala
+++ b/modules/tests/src/test/scala/issue/181.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package tests.issue
+
+import cats.implicits._
+import skunk._
+import skunk.codec.all._
+import skunk.implicits._
+import tests.SkunkTest
+import skunk.exception.PostgresErrorException
+
+// https://github.com/tpolecat/skunk/issues/181
+case object Test181 extends SkunkTest {
+
+  def func(level: String): Command[Void] =
+    sql"""
+      CREATE OR REPLACE FUNCTION test181_#$level() RETURNS real AS $$$$
+      BEGIN
+          RAISE #$level 'This message contains non-ASCII characters: ü ø 😀 ש';
+          RETURN 4.2;
+      END;
+      $$$$ LANGUAGE plpgsql;
+    """.command
+
+  sessionTest(s"non-ASCII error message (EXCEPTION)") { s =>
+    for {
+      _ <- s.execute(func("EXCEPTION"))
+      _ <- s.unique(sql"select test181_EXCEPTION()".query(float4)).assertFailsWith[PostgresErrorException](show = true)
+    } yield ("ok")
+  }
+
+  sessionTest(s"non-ASCII error message (WARNING)") { s =>
+    for {
+      _ <- s.execute(func("WARNING"))
+      a <- s.unique(sql"select test181_WARNING()".query(float4))
+      _ <- assertEqual("4.2", a, 4.2f)
+    } yield ("ok")
+  }
+
+    sessionTest(s"non-ASCII error message (NOTICE)") { s =>
+    for {
+      _ <- s.execute(func("NOTICE"))
+      a <- s.unique(sql"select test181_NOTICE()".query(float4))
+      _ <- assertEqual("4.2", a, 4.2f)
+    } yield ("ok")
+  }
+
+}


### PR DESCRIPTION
This ended up being kind of big.

- The issue in #181 is due to the error/notice decoder not reading messages in utf8. This is fixed, and everything now uses `utf8z` instead of `cstring`. There remains the weird case of startup errors prior to the session being established, where text encoding is entirely up to the server. We assume for now that it will be something readable as UTF-8.
- In the process of testing this I discovered that `sync` really needs to discard buffered messages. This is implemented, with a 100ms delay in the hopes of buffering any pending messages. Because it only happens in error conditions this probably isn't a huge deal but it does needs improvement I think. Sleeping is bad.
- Also discovered the `float4` codec was mistakenly mapping to `Double`.

Fixes #181 
