### PR TITLE
fix protocol bug, remove workaround

### DIFF
--- a/modules/core/src/main/scala/Session.scala
+++ b/modules/core/src/main/scala/Session.scala
@@ -229,7 +229,7 @@ object Session {
    * @param strategy
    * @group Constructors
    */
-  def pooled[F[_]: Concurrent: ContextShift: Trace: Timer](
+  def pooled[F[_]: Concurrent: ContextShift: Trace](
     host:         String,
     port:         Int            = 5432,
     user:         String,
@@ -263,7 +263,7 @@ object Session {
    * single-session pool. This method is shorthand for `Session.pooled(..., max = 1, ...).flatten`.
    * @see pooled
    */
-  def single[F[_]: Concurrent: ContextShift: Trace: Timer](
+  def single[F[_]: Concurrent: ContextShift: Trace](
     host:         String,
     port:         Int            = 5432,
     user:         String,
@@ -290,7 +290,7 @@ object Session {
     ).flatten
 
 
-  def fromSocketGroup[F[_]: Concurrent: ContextShift: Trace: Timer](
+  def fromSocketGroup[F[_]: Concurrent: ContextShift: Trace](
     socketGroup:  SocketGroup,
     host:         String,
     port:         Int            = 5432,

--- a/modules/core/src/main/scala/net/MessageSocket.scala
+++ b/modules/core/src/main/scala/net/MessageSocket.scala
@@ -31,9 +31,6 @@ trait MessageSocket[F[_]] {
   def expect[B](f: PartialFunction[BackendMessage, B])(implicit or: Origin): F[B]
   def flatExpect[B](f: PartialFunction[BackendMessage, F[B]])(implicit or: Origin): F[B]
 
-  /** Discard any buffered messages and send a `Sync` message. */
-  def sync: F[Unit]
-
 }
 
 object MessageSocket {
@@ -74,9 +71,6 @@ object MessageSocket {
 
         override def history(max: Int): F[List[Either[Any, Any]]] =
           cb.dequeueChunk1(max: Int).map(_.toList)
-
-        def sync: F[Unit] =
-          send(skunk.net.message.Sync)
 
       }
     }

--- a/modules/core/src/main/scala/net/Protocol.scala
+++ b/modules/core/src/main/scala/net/Protocol.scala
@@ -16,7 +16,6 @@ import scala.concurrent.duration.FiniteDuration
 import skunk.util.Typer
 import natchez.Trace
 import fs2.io.tcp.SocketGroup
-import cats.effect.Timer
 
 /**
  * Interface for a Postgres database, expressed through high-level operations that rely on exchange
@@ -184,7 +183,7 @@ object Protocol {
    * @param host  Postgres server host
    * @param port  Postgres port, default 5432
    */
-  def apply[F[_]: Concurrent: ContextShift: Trace: Timer](
+  def apply[F[_]: Concurrent: ContextShift: Trace](
     host:         String,
     port:         Int,
     debug:        Boolean,

--- a/modules/core/src/main/scala/net/protocol/Bind.scala
+++ b/modules/core/src/main/scala/net/protocol/Bind.scala
@@ -60,7 +60,7 @@ object Bind {
       ): F[Unit] =
         for {
           hi <- history(Int.MaxValue)
-          _  <- sync
+          _  <- send(Sync)
           _  <- expect { case ReadyForQuery(_) => }
           a  <- PostgresErrorException.raiseError[F, Unit](
                   sql             = statement.statement.sql,

--- a/modules/core/src/main/scala/net/protocol/Execute.scala
+++ b/modules/core/src/main/scala/net/protocol/Execute.scala
@@ -30,7 +30,7 @@ object Execute {
             _  <- send(ExecuteMessage(portal.id.value, 0))
             _  <- send(Flush)
             c  <- flatExpect {
-              case CommandComplete(c)  => sync *> expect { case ReadyForQuery(_) => c } // https://github.com/tpolecat/skunk/issues/210
+              case CommandComplete(c)  => send(Sync) *> expect { case ReadyForQuery(_) => c } // https://github.com/tpolecat/skunk/issues/210
               case ErrorResponse(info) => syncAndFail[A](portal, info)
             }
           } yield c
@@ -52,7 +52,7 @@ object Execute {
       def syncAndFail[A](portal: Protocol.CommandPortal[F, A], info: Map[Char, String]): F[Completion] =
         for {
           hi <- history(Int.MaxValue)
-          _  <- sync
+          _  <- send(Sync)
           _  <- expect { case ReadyForQuery(_) => }
           a  <- new PostgresErrorException(
                   sql             = portal.preparedCommand.command.sql,

--- a/modules/core/src/main/scala/net/protocol/Parse.scala
+++ b/modules/core/src/main/scala/net/protocol/Parse.scala
@@ -60,7 +60,7 @@ object Parse {
       def syncAndFail(statement: Statement[_], info: Map[Char, String]): F[Unit] =
         for {
           hi <- history(Int.MaxValue)
-          _  <- sync
+          _  <- send(Sync)
           _  <- expect { case ReadyForQuery(_) => }
           a  <- new PostgresErrorException(
                   sql       = statement.sql,

--- a/modules/core/src/main/scala/net/protocol/package.scala
+++ b/modules/core/src/main/scala/net/protocol/package.scala
@@ -21,9 +21,6 @@ import skunk.util.Origin
   def send[F[_], A: FrontendMessage](a: A)(implicit ev: MessageSocket[F]): F[Unit] =
     ev.send(a)
 
-  def sync[F[_]](implicit ev: MessageSocket[F]): F[Unit] =
-    ev.sync
-
   def history[F[_]](max: Int)(implicit ev: MessageSocket[F]): F[List[Either[Any, Any]]] =
     ev.history(max)
 

--- a/modules/example/src/main/scala/Http4s.scala
+++ b/modules/example/src/main/scala/Http4s.scala
@@ -101,7 +101,7 @@ object Http4sExample extends IOApp {
    * Given a `SocketGroup` we can construct a session resource, and from that construct a
    * `Countries` resource.
    */
-  def countriesFromSocketGroup[F[_]: Concurrent: ContextShift: Trace: Timer](
+  def countriesFromSocketGroup[F[_]: Concurrent: ContextShift: Trace](
     socketGroup: SocketGroup
   ): Resource[F, PooledCountries[F]] =
     Session.fromSocketGroup(
@@ -114,7 +114,7 @@ object Http4sExample extends IOApp {
     ).flatMap(countriesFromSession(_))
 
   /** Resource yielding a pool of `Countries`, backed by a single `Blocker` and `SocketGroup`. */
-  def pool[F[_]: Concurrent: ContextShift: Trace: Timer]: Resource[F, Resource[F, Countries[F]]] =
+  def pool[F[_]: Concurrent: ContextShift: Trace]: Resource[F, Resource[F, Countries[F]]] =
     for {
       b  <- Blocker[F]
       sg <- SocketGroup[F](b)
@@ -148,7 +148,7 @@ object Http4sExample extends IOApp {
    * Using `pool` above we can create `HttpRoutes` resource. We also add some standard tracing
    * middleware while we're at it.
    */
-  def routes[F[_]: Concurrent: ContextShift: Trace: Timer]: Resource[F, HttpRoutes[F]] =
+  def routes[F[_]: Concurrent: ContextShift: Trace]: Resource[F, HttpRoutes[F]] =
     pool.map(p => natchezMiddleware(countryRoutes(p)))
 
   /** Our Natchez `EntryPoint` resource. */

--- a/modules/example/src/main/scala/Minimal2.scala
+++ b/modules/example/src/main/scala/Minimal2.scala
@@ -20,7 +20,7 @@ import io.jaegertracing.Configuration.ReporterConfiguration
 
 object Minimal2 extends IOApp {
 
-  def session[F[_]: Concurrent: ContextShift: Trace: Timer]: Resource[F, Session[F]] =
+  def session[F[_]: Concurrent: ContextShift: Trace]: Resource[F, Session[F]] =
     Session.single(
       host     = "localhost",
       port     = 5432,
@@ -51,7 +51,7 @@ object Minimal2 extends IOApp {
       }
     }
 
-  def runF[F[_]: Concurrent: ContextShift: Trace: Parallel: Timer]: F[ExitCode] =
+  def runF[F[_]: Concurrent: ContextShift: Trace: Parallel]: F[ExitCode] =
     session.use { s =>
       List("A%", "B%").parTraverse(p => lookup(p, s))
     } as ExitCode.Success

--- a/modules/example/src/main/scala/Transaction.scala
+++ b/modules/example/src/main/scala/Transaction.scala
@@ -11,7 +11,7 @@ import natchez.Trace.Implicits.noop
 
 object Transaction extends IOApp {
 
-  def session[F[_]: Concurrent: ContextShift: Timer]: Resource[F, Session[F]] =
+  def session[F[_]: Concurrent: ContextShift]: Resource[F, Session[F]] =
     Session.single(
       host     = "localhost",
       port     = 5432,
@@ -20,7 +20,7 @@ object Transaction extends IOApp {
       password = Some("banana"),
     )
 
-  def runS[F[_]: Concurrent: ContextShift: Timer]: F[_] =
+  def runS[F[_]: Concurrent: ContextShift]: F[_] =
     session[F].use { s =>
       s.transaction.use { t =>
         for {


### PR DESCRIPTION
This undoes the hack where we throw away buffered messages prior to issuing a `Sync`, and fixes the underlying issue correctly (it was sending `Sync` in the simple query protocol for unrolling row data, which caused duplicate `ReadyForQuery` responses). Anyway, fixed. Apologies to all concerned.