### PR TITLE
add handlers and tests for weird/unsupported cases

### DIFF
--- a/modules/core/src/main/scala/data/Completion.scala
+++ b/modules/core/src/main/scala/data/Completion.scala
@@ -31,6 +31,7 @@ object Completion {
   case object CreateType         extends Completion
   case object DropType           extends Completion
   case object CreateFunction     extends Completion
+  case class  Copy(count: Int)   extends Completion
   // more ...
 
   /**

--- a/modules/core/src/main/scala/exception/CopyNotSupportedException.scala
+++ b/modules/core/src/main/scala/exception/CopyNotSupportedException.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.exception
+
+import skunk.Statement
+
+class CopyNotSupportedException(stmt: Statement[_]) extends SkunkException(
+  message   = "COPY is not yet supported, sorry.",
+  sql       = Some(stmt.sql),
+  sqlOrigin = Some(stmt.origin),
+)

--- a/modules/core/src/main/scala/exception/EmptyStatementException.scala
+++ b/modules/core/src/main/scala/exception/EmptyStatementException.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.exception
+
+import skunk.Statement
+
+class EmptyStatementException(stmt: Statement[_]) extends SkunkException(
+  message   = "Query is empty.",
+  sql       = Some(stmt.sql),
+  sqlOrigin = Some(stmt.origin),
+)

--- a/modules/core/src/main/scala/exception/UnexpectedDataException.scala
+++ b/modules/core/src/main/scala/exception/UnexpectedDataException.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.exception
+
+import skunk.Command
+
+final case class UnexpectedDataException(
+  command: Command[_],
+) extends SkunkException(
+  sql       = Some(command.sql),
+  message   = "Command returns data.",
+  hint      = Some(s"This ${framed("command")} returns row data. Use a ${framed("query")} instead."),
+  sqlOrigin = Some(command.origin),
+)

--- a/modules/core/src/main/scala/net/message/BackendMessage.scala
+++ b/modules/core/src/main/scala/net/message/BackendMessage.scala
@@ -27,7 +27,10 @@ object BackendMessage {
        case BindComplete.Tag          => BindComplete.decoder
        case CloseComplete.Tag         => CloseComplete.decoder
        case CommandComplete.Tag       => CommandComplete.decoder
+       case CopyData.Tag              => CopyData.decoder
+       case CopyDone.Tag              => CopyDone.decoder
        case CopyInResponse.Tag        => CopyInResponse.decoder
+       case CopyOutResponse.Tag       => CopyOutResponse.decoder
        case EmptyQueryResponse.Tag    => EmptyQueryResponse.decoder
        case ErrorResponse.Tag         => ErrorResponse.decoder
        case NoData.Tag                => NoData.decoder

--- a/modules/core/src/main/scala/net/message/BackendMessage.scala
+++ b/modules/core/src/main/scala/net/message/BackendMessage.scala
@@ -27,6 +27,8 @@ object BackendMessage {
        case BindComplete.Tag          => BindComplete.decoder
        case CloseComplete.Tag         => CloseComplete.decoder
        case CommandComplete.Tag       => CommandComplete.decoder
+       case CopyInResponse.Tag        => CopyInResponse.decoder
+       case EmptyQueryResponse.Tag    => EmptyQueryResponse.decoder
        case ErrorResponse.Tag         => ErrorResponse.decoder
        case NoData.Tag                => NoData.decoder
        case NotificationResponse.Tag  => NotificationResponse.decoder

--- a/modules/core/src/main/scala/net/message/CommandComplete.scala
+++ b/modules/core/src/main/scala/net/message/CommandComplete.scala
@@ -40,6 +40,7 @@ object CommandComplete {
     val Delete: Regex = """DELETE (\d+)""".r
     val Update: Regex = """UPDATE (\d+)""".r
     val Insert: Regex = """INSERT (\d+ \d+)""".r
+    val Copy:   Regex = """COPY (\d+)""".r
   }
 
   //TODO: maybe make lazy val
@@ -68,6 +69,7 @@ object CommandComplete {
     case Patterns.Delete(s) => apply(Completion.Delete(s.toInt))
     case Patterns.Update(s) => apply(Completion.Update(s.toInt))
     case Patterns.Insert(s) => apply(Completion.Insert(s.drop(2).toInt))
+    case Patterns.Copy(s)   => apply(Completion.Copy(s.toInt))
     // more .. fill in as we hit them
 
     case s                  => apply(Completion.Unknown(s))

--- a/modules/core/src/main/scala/net/message/CopyData.scala
+++ b/modules/core/src/main/scala/net/message/CopyData.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.net.message
+
+import scodec.Decoder
+import scodec.bits.ByteVector
+import scodec.codecs.bytes
+
+final case class CopyData(data: ByteVector) extends BackendMessage {
+  override def toString = s"CopyData(...)"
+}
+
+object CopyData {
+  final val Tag = 'd'
+  val decoder: Decoder[CopyData] = bytes.map(bv => CopyData(bv)) // TODO!
+}

--- a/modules/core/src/main/scala/net/message/CopyDone.scala
+++ b/modules/core/src/main/scala/net/message/CopyDone.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.net.message
+
+import scodec.Decoder
+
+case object CopyDone extends BackendMessage {
+  final val Tag = 'c'
+  val decoder: Decoder[CopyDone.type] = Decoder.point(CopyDone)
+}

--- a/modules/core/src/main/scala/net/message/CopyFail.scala
+++ b/modules/core/src/main/scala/net/message/CopyFail.scala
@@ -1,0 +1,7 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.net.message
+
+case object CopyFail extends ConstFrontendMessage('f')

--- a/modules/core/src/main/scala/net/message/CopyInResponse.scala
+++ b/modules/core/src/main/scala/net/message/CopyInResponse.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.net.message
+
+import scodec.Decoder
+import scodec.bits.ByteVector
+import scodec.codecs.bytes
+
+final case class CopyInResponse(data: ByteVector) extends BackendMessage {
+  override def toString = s"CopyInResponse(...)"
+}
+
+object CopyInResponse {
+  final val Tag = 'G'
+  val decoder: Decoder[CopyInResponse] = bytes.map(bv => CopyInResponse(bv)) // TODO!
+}

--- a/modules/core/src/main/scala/net/message/CopyOutResponse.scala
+++ b/modules/core/src/main/scala/net/message/CopyOutResponse.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.net.message
+
+import scodec.Decoder
+import scodec.bits.ByteVector
+import scodec.codecs.bytes
+
+final case class CopyOutResponse(data: ByteVector) extends BackendMessage {
+  override def toString = s"CopyOutResponse(...)"
+}
+
+object CopyOutResponse {
+  final val Tag = 'H'
+  val decoder: Decoder[CopyOutResponse] = bytes.map(bv => CopyOutResponse(bv)) // TODO!
+}

--- a/modules/core/src/main/scala/net/message/EmptyQueryResponse.scala
+++ b/modules/core/src/main/scala/net/message/EmptyQueryResponse.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.net.message
+
+import scodec.Decoder
+
+case object EmptyQueryResponse extends BackendMessage {
+  final val Tag = 'I'
+  val decoder: Decoder[EmptyQueryResponse.type] = Decoder.point(EmptyQueryResponse)
+}

--- a/modules/core/src/main/scala/net/protocol/Query.scala
+++ b/modules/core/src/main/scala/net/protocol/Query.scala
@@ -164,7 +164,11 @@ object Query {
             "command.sql" -> command.sql
           ) *> send(QueryMessage(command.sql)) *> flatExpect {
 
-            case CommandComplete(c) => finishUp(command).as(c)
+            case CommandComplete(c) =>
+              finishUp(command).as(c)
+
+            case EmptyQueryResponse =>
+              finishUp(command) *> new EmptyStatementException(command).raiseError[F, Completion]
 
             case ErrorResponse(e) =>
               for {

--- a/modules/core/src/main/scala/net/protocol/Query.scala
+++ b/modules/core/src/main/scala/net/protocol/Query.scala
@@ -8,12 +8,15 @@ import cats.MonadError
 import cats.implicits._
 import skunk.{ Command, Void }
 import skunk.data.Completion
-import skunk.exception.{ ColumnAlignmentException, NoDataException, PostgresErrorException }
+import skunk.exception._
 import skunk.net.message.{ Query => QueryMessage, _ }
 import skunk.net.MessageSocket
 import skunk.util.Typer
 import skunk.exception.UnknownOidException
 import natchez.Trace
+import skunk.Statement
+import skunk.exception.SkunkException
+import skunk.exception.EmptyStatementException
 
 trait Query[F[_]] {
   def apply(command: Command[Void]): F[Completion]
@@ -24,6 +27,37 @@ object Query {
 
   def apply[F[_]: MonadError[?[_], Throwable]: Exchange: MessageSocket: Trace]: Query[F] =
     new Unroll[F] with Query[F] {
+
+      def finishUp(stmt: Statement[_], multipleStatements: Boolean = false): F[Unit] =
+        receive.flatMap {
+
+          case ReadyForQuery(_) =>
+            new SkunkException(
+              message   = "Multi-statement queries and commands are not supported.",
+              hint      = Some("Break up semicolon-separated statements and execute them independently."),
+              sql       = Some(stmt.sql),
+              sqlOrigin = Some(stmt.origin),
+            ).raiseError[F, Unit].whenA(multipleStatements)
+
+          case RowDescription(_) | RowData(_) | CommandComplete(_) | ErrorResponse(_) | EmptyQueryResponse =>
+            finishUp(stmt, true)
+
+          case CopyInResponse(_) =>
+              send(CopyFail)                      *>
+              expect { case ErrorResponse(_) => } *>
+              finishUp(stmt, true)
+
+          // case CopyOutReponse =>
+
+        }
+
+      // If there is an error we just want to receive and discard everything until we have seen
+      // CommandComplete followed by ReadyForQuery.
+      def discard(stmt: Statement[_]): F[Unit] =
+        receive.flatMap {
+          case RowData(_)         => discard(stmt)
+          case CommandComplete(_) => finishUp(stmt)
+        }
 
       override def apply[B](query: skunk.Query[Void, B], ty: Typer): F[List[B]] =
         exchange("query") {
@@ -51,27 +85,39 @@ object Query {
                       encoder        = Void.codec,
                       rowDescription = td,
                       decoder        = query.decoder,
-                    ).map(_._1) <* expect { case ReadyForQuery(_) => }
+                    ).map(_._1) <* finishUp(query)
                   } else {
-                    discard *> ColumnAlignmentException(query, td).raiseError[F, List[B]]
+                    discard(query) *> ColumnAlignmentException(query, td).raiseError[F, List[B]]
                   }
 
                 case Left(err) =>
-                  discard *> UnknownOidException(query, err, ty.strategy).raiseError[F, List[B]]
+                  discard(query) *> UnknownOidException(query, err, ty.strategy).raiseError[F, List[B]]
 
               }
+
+            // We don't support COPY FROM STDIN yet but we do need to be able to clean up if a user
+            // tries it.
+            case CopyInResponse(_) =>
+              send(CopyFail)  *>
+              expect { case ErrorResponse(_) => } *>
+              finishUp(query) *>
+              new CopyNotSupportedException(query).raiseError[F, List[B]]
+
+            // Query is empty, whitespace, all comments, etc.
+            case EmptyQueryResponse =>
+              finishUp(query) *> new EmptyStatementException(query).raiseError[F, List[B]]
 
             // If we get CommandComplete it means our Query was actually a Command. Postgres doesn't
             // distinguish these but we do, so this is an error.
             case CommandComplete(_) =>
-              expect { case ReadyForQuery(_) => } *> NoDataException(query).raiseError[F, List[B]]
+              finishUp(query) *> NoDataException(query).raiseError[F, List[B]]
 
             // If we get an ErrorResponse it means there was an error in the query. In this case we
             // simply await ReadyForQuery and then raise an error.
             case ErrorResponse(e) =>
               for {
                 hi <- history(Int.MaxValue)
-                _  <- expect { case ReadyForQuery(_) => }
+                _  <- finishUp(query)
                 rs <- (new PostgresErrorException(
                         sql       = query.sql,
                         sqlOrigin = Some(query.origin),
@@ -87,7 +133,7 @@ object Query {
               for {
                 hi <- history(Int.MaxValue)
                 _  <- expect { case CommandComplete(_) => }
-                _  <- expect { case ReadyForQuery(_) => }
+                _  <- finishUp(query)
                 rs <- (new PostgresErrorException(
                         sql       = query.sql,
                         sqlOrigin = Some(query.origin),
@@ -105,14 +151,11 @@ object Query {
             "command.sql" -> command.sql
           ) *> send(QueryMessage(command.sql)) *> flatExpect {
 
-            case CommandComplete(c) =>
-              for {
-                _ <- expect { case ReadyForQuery(_) => }
-              } yield c
+            case CommandComplete(c) => finishUp(command).as(c)
 
             case ErrorResponse(e) =>
               for {
-                _ <- expect { case ReadyForQuery(_) => }
+                _ <- finishUp(command)
                 h <- history(Int.MaxValue)
                 c <- new PostgresErrorException(command.sql, Some(command.origin), e, h, Nil, None).raiseError[F, Completion]
               } yield c
@@ -120,23 +163,26 @@ object Query {
             case NoticeResponse(e) =>
               for {
                 _ <- expect { case CommandComplete(_) => }
-                _ <- expect { case ReadyForQuery(_) =>  }
+                _ <- finishUp(command)
                 h <- history(Int.MaxValue)
                 c <- new PostgresErrorException(command.sql, Some(command.origin), e, h, Nil, None).raiseError[F, Completion]
               } yield c
 
-            // TODO: case RowDescription => oops, this returns rows, it needs to be a query
+            // If we get rows back it means this should have been a query!
+            case RowDescription(_) =>
+              finishUp(command) *> UnexpectedDataException(command).raiseError[F, Completion]
 
-          }
+            // We don't support COPY FROM STDIN yet but we do need to be able to clean up if a user
+            // tries it.
+            case CopyInResponse(_) =>
+              send(CopyFail)  *>
+              expect { case ErrorResponse(_) => } *>
+              finishUp(command) *>
+              new CopyNotSupportedException(command).raiseError[F, Completion]
+            }
+
         }
 
-      // If there is an error we just want to receive and discard everything until we have seen
-      // CommandComplete followed by ReadyForQuery.
-      val discard: F[Unit] =
-        receive.flatMap {
-          case RowData(_)         => discard
-          case CommandComplete(_) => expect { case ReadyForQuery(_) => }
-        }
 
 
     }

--- a/modules/core/src/main/scala/util/Pretty.scala
+++ b/modules/core/src/main/scala/util/Pretty.scala
@@ -27,7 +27,10 @@ object Pretty {
 
     // Normalize tabs
     val s3 = {
-      val drop = s2.linesIterator.map(_.takeWhile(_ == ' ').length).min
+      val drop = {
+        val ns = s2.linesIterator.map(_.takeWhile(_ == ' ').length)
+        if (ns.isEmpty) 0 else ns.min
+      }
       s2.linesIterator.map(s => s"  ${Console.GREEN}" + s.drop(drop) + Console.RESET).mkString("\n")
     }
 

--- a/modules/tests/src/main/scala/ffstest/FFramework.scala
+++ b/modules/tests/src/main/scala/ffstest/FFramework.scala
@@ -107,7 +107,7 @@ case class FTask(taskDef: TaskDef, testClassLoader: ClassLoader) extends Task {
       eventHandler.handle(event)
     }
 
-    obj.tests.traverse_ { case (name, fa) =>
+    obj.tests.parTraverse_ { case (name, fa) =>
       type AE = AssertionError // to make the lines shorter below :-\
       FTask.timed(obj.ioContextShift.shift *> fa).attempt.map {
         case Right((ms, a)) => report(GREEN, s"✓ $name ($a, $ms ms)",      FEvent(Success, duration = ms))

--- a/modules/tests/src/test/scala/CopyInTest.scala
+++ b/modules/tests/src/test/scala/CopyInTest.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package tests
+
+import skunk.implicits._
+import skunk.codec.all._
+import skunk.exception.CopyNotSupportedException
+
+object CopyInTest extends SkunkTest {
+
+  sessionTest("copy in") { s =>
+    s.execute(sql"COPY country FROM STDIN".query(int4))
+      .assertFailsWith[CopyNotSupportedException] *> s.assertHealthy
+  }
+
+}

--- a/modules/tests/src/test/scala/CopyInTest.scala
+++ b/modules/tests/src/test/scala/CopyInTest.scala
@@ -7,6 +7,8 @@ package tests
 import skunk.implicits._
 import skunk.codec.all._
 import skunk.exception.CopyNotSupportedException
+import cats.effect.IO
+import skunk.exception.NoDataException
 
 object CopyInTest extends SkunkTest {
 
@@ -17,6 +19,18 @@ object CopyInTest extends SkunkTest {
 
   sessionTest("copy in (as command)") { s =>
     s.execute(sql"COPY country FROM STDIN".command)
+      .assertFailsWith[CopyNotSupportedException] *> s.assertHealthy
+  }
+
+  sessionTest("copy in (extended, query)") { s =>
+    s.prepare(sql"COPY country FROM STDIN".query(int4))
+      .use { _ => IO.unit }
+      .assertFailsWith[NoDataException] *> s.assertHealthy // can't distinguish this from other cases, probably will be an FAQ
+  }
+
+  sessionTest("copy in (extended command)") { s =>
+    s.prepare(sql"COPY country FROM STDIN".command)
+      .use { _.execute(skunk.Void) }
       .assertFailsWith[CopyNotSupportedException] *> s.assertHealthy
   }
 

--- a/modules/tests/src/test/scala/CopyOutTest.scala
+++ b/modules/tests/src/test/scala/CopyOutTest.scala
@@ -8,15 +8,15 @@ import skunk.implicits._
 import skunk.codec.all._
 import skunk.exception.CopyNotSupportedException
 
-object CopyInTest extends SkunkTest {
+object CopyOutTest extends SkunkTest {
 
-  sessionTest("copy in") { s =>
-    s.execute(sql"COPY country FROM STDIN".query(int4))
+  sessionTest("copy out") { s =>
+    s.execute(sql"COPY country TO STDOUT".query(int4))
       .assertFailsWith[CopyNotSupportedException] *> s.assertHealthy
   }
 
-  sessionTest("copy in (as command)") { s =>
-    s.execute(sql"COPY country FROM STDIN".command)
+  sessionTest("copy out (as command)") { s =>
+    s.execute(sql"COPY country TO STDOUT".command)
       .assertFailsWith[CopyNotSupportedException] *> s.assertHealthy
   }
 

--- a/modules/tests/src/test/scala/EmptyStatementTest.scala
+++ b/modules/tests/src/test/scala/EmptyStatementTest.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package tests
+
+import skunk.implicits._
+import skunk.codec.all._
+import skunk.exception.EmptyStatementException
+
+object EmptyStatementTest extends SkunkTest {
+
+  sessionTest("empty query") { s =>
+    s.execute(sql"".query(int4))
+      .assertFailsWith[EmptyStatementException] *> s.assertHealthy
+  }
+
+  sessionTest("comment-only query") { s =>
+    s.execute(sql"-- only a comment!".query(int4))
+      .assertFailsWith[EmptyStatementException] *> s.assertHealthy
+  }
+
+}

--- a/modules/tests/src/test/scala/EmptyStatementTest.scala
+++ b/modules/tests/src/test/scala/EmptyStatementTest.scala
@@ -4,19 +4,36 @@
 
 package tests
 
+import cats.effect.IO
 import skunk.implicits._
 import skunk.codec.all._
 import skunk.exception.EmptyStatementException
+import skunk.exception.NoDataException
 
 object EmptyStatementTest extends SkunkTest {
 
-  sessionTest("empty query") { s =>
+  sessionTest("comment-only query") { s =>
+    s.execute(sql"-- only a comment!".query(int4))
+      .assertFailsWith[EmptyStatementException] *> s.assertHealthy
+  }
+
+  sessionTest("empty query (simple query)") { s =>
     s.execute(sql"".query(int4))
       .assertFailsWith[EmptyStatementException] *> s.assertHealthy
   }
 
-  sessionTest("comment-only query") { s =>
-    s.execute(sql"-- only a comment!".query(int4))
+  sessionTest("empty query (simple command)") { s =>
+    s.execute(sql"".command)
+      .assertFailsWith[EmptyStatementException] *> s.assertHealthy
+  }
+
+  sessionTest("empty query (extended query)") { s =>
+    s.prepare(sql"".query(int4)).use(_ => IO.unit)
+      .assertFailsWith[NoDataException] *> s.assertHealthy
+  }
+
+  sessionTest("empty query (extended command)") { s =>
+    s.prepare(sql"".command).use(_.execute(skunk.Void))
       .assertFailsWith[EmptyStatementException] *> s.assertHealthy
   }
 

--- a/modules/tests/src/test/scala/MultipleStatementsTest.scala
+++ b/modules/tests/src/test/scala/MultipleStatementsTest.scala
@@ -13,7 +13,7 @@ import skunk.exception.SkunkException
 object MultipleStatementsTest extends SkunkTest {
 
   val statements: List[(Query[Void,Int], Command[Void])] =
-    List("select 1","commit","copy country from stdin")
+    List("select 1","commit","copy country from stdin","copy country to stdout") // one per protocol
       .permutations
       .toList
       .map { ss => ss.intercalate(";") }

--- a/modules/tests/src/test/scala/MultipleStatementsTest.scala
+++ b/modules/tests/src/test/scala/MultipleStatementsTest.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package tests
+
+import cats.implicits._
+import skunk._
+import skunk.implicits._
+import skunk.codec.all._
+import skunk.exception.SkunkException
+
+object MultipleStatementsTest extends SkunkTest {
+
+  val statements: List[(Query[Void,Int], Command[Void])] =
+    List("select 1","commit","copy country from stdin")
+      .permutations
+      .toList
+      .map { ss => ss.intercalate(";") }
+      .map { s => (sql"#$s".query(int4), sql"#$s".command) }
+
+  statements.foreach { case (q, c) =>
+    sessionTest(s"query: ${q.sql}") { s =>  s.execute(q).assertFailsWith[SkunkException] *> s.assertHealthy }
+    sessionTest(s"command: ${c.sql}") { s =>  s.execute(c).assertFailsWith[SkunkException] *> s.assertHealthy }
+  }
+
+}


### PR DESCRIPTION
This adds handlers for some error conditions in the **simple query protocol** that would otherwise cause a protocol error.
- [x] empty statements
- [x] multiple statements protocol (not supported)
- [x] `COPY ... FROM STDIN` (not supported)
- [x] `COPY ... TO STDOUT` (not supported)

Also decided to add

- [x] All the above, with extended protocol.