### PR TITLE
doc odyssey

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -170,4 +170,7 @@ lazy val docs = project
     Compile / paradox / sourceDirectory := mdocOut.value,
     makeSite := makeSite.dependsOn(mdoc.toTask("")).value,
     mdocExtraArguments := Seq("--no-link-hygiene"), // paradox handles this
+    libraryDependencies ++= Seq(
+      "org.tpolecat"  %% "natchez-jaeger"      % "0.0.11",
+    ),
 )

--- a/modules/core/src/main/scala/PreparedCommand.scala
+++ b/modules/core/src/main/scala/PreparedCommand.scala
@@ -9,6 +9,7 @@ import cats.effect.Bracket
 import skunk.data.Completion
 import skunk.net.Protocol
 import skunk.util.Origin
+import fs2.Pipe
 
 /**
  * A prepared command, valid for the life of its defining `Session`.
@@ -17,6 +18,13 @@ import skunk.util.Origin
 trait PreparedCommand[F[_], A] { outer =>
 
   def execute(args: A)(implicit origin: Origin): F[Completion]
+
+  /**
+   * A `Pipe` that executes this `PreparedCommand` for each input value, yielding a stream of
+   * `Completion`s.
+   */
+  def pipe(implicit origin: Origin): Pipe[F, A, Completion] =
+    _.evalMap(execute)
 
   /**
    * Transform this `PreparedCommand` by a given `FunctionK`.

--- a/modules/core/src/main/scala/PreparedQuery.scala
+++ b/modules/core/src/main/scala/PreparedQuery.scala
@@ -8,7 +8,7 @@ import cats._
 import cats.arrow.Profunctor
 import cats.effect._
 import cats.implicits._
-import fs2.{ Chunk, Stream }
+import fs2.{ Chunk, Stream, Pipe }
 import skunk.exception.SkunkException
 import skunk.net.Protocol
 import skunk.util.{ CallSite, Origin }
@@ -44,6 +44,13 @@ trait PreparedQuery[F[_], A, B] {
    * Fetch and return exactly one row, raising an exception if there are more or fewer.
    */
   def unique(args: A)(implicit or: Origin): F[B]
+
+  /**
+   * A `Pipe` that executes this `PreparedQuery` for each input value, concatenating the resulting
+   * streams. See `stream` for details on the `chunkSize` parameter.
+   */
+  def pipe(chunkSize: Int)(implicit or: Origin): Pipe[F, A, B] =
+    _.flatMap(stream(_, chunkSize))
 
 }
 

--- a/modules/core/src/main/scala/Session.scala
+++ b/modules/core/src/main/scala/Session.scala
@@ -148,7 +148,7 @@ trait Session[F[_]] {
    * A named asynchronous channel that can be used for inter-process communication.
    * @group Channels
    */
-  def channel(name: Identifier): Channel[F, String, Notification]
+  def channel(name: Identifier): Channel[F, String, String]
 
   /**
    * Resource that wraps a transaction block. A transaction is begun before entering the `use`
@@ -335,7 +335,7 @@ object Session {
         override def execute(command: Command[Void]): F[Completion] =
           proto.execute(command)
 
-        override def channel(name: Identifier): Channel[F, String, Notification] =
+        override def channel(name: Identifier): Channel[F, String, String] =
           Channel.fromNameAndProtocol(name, proto)
 
         override def parameters: Signal[F, Map[String, String]] =
@@ -396,7 +396,7 @@ object Session {
     def mapK[G[_]: Applicative: Defer](fk: F ~> G): Session[G] =
       new Session[G] {
         override val typer: Typer = outer.typer
-        override def channel(name: Identifier): Channel[G,String,Notification] = outer.channel(name).mapK(fk)
+        override def channel(name: Identifier): Channel[G,String,String] = outer.channel(name).mapK(fk)
         override def execute(command: Command[Void]): G[Completion] = fk(outer.execute(command))
         override def execute[A](query: Query[Void,A]): G[List[A]] = fk(outer.execute(query))
         override def option[A](query: Query[Void,A]): G[Option[A]] = fk(outer.option(query))

--- a/modules/core/src/main/scala/data/Notification.scala
+++ b/modules/core/src/main/scala/data/Notification.scala
@@ -5,4 +5,21 @@
 package skunk
 package data
 
-final case class Notification(pid: Int, channel: Identifier, value: String)
+import cats._
+import cats.implicits._
+
+final case class Notification[A](pid: Int, channel: Identifier, value: A) {
+  def map[B](f: A => B): Notification[B] = copy(value = f(value))
+}
+
+object Notification {
+
+  implicit val TraverseNotification: Traverse[Notification] =
+    new Traverse[Notification] {
+      def foldLeft[A, B](fa: Notification[A], b: B)(f: (B, A) => B): B = f(b, fa.value)
+      def foldRight[A, B](fa: Notification[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = f(fa.value, lb)
+      def traverse[G[_]: Applicative, A, B](fa: Notification[A])(f: A => G[B]): G[Notification[B]] = f(fa.value).map(b => fa.copy(value = b))
+      override def map[A, B](fa: Notification[A])(f: A => B): Notification[B] = fa.map(f)
+    }
+
+}

--- a/modules/core/src/main/scala/net/Protocol.scala
+++ b/modules/core/src/main/scala/net/Protocol.scala
@@ -32,7 +32,7 @@ trait Protocol[F[_]] {
    * @see [[https://www.postgresql.org/docs/10/static/sql-listen.html LISTEN]]
    * @see [[https://www.postgresql.org/docs/10/static/sql-notify.html NOTIFY]]
    */
-  def notifications(maxQueued: Int): Stream[F, Notification]
+  def notifications(maxQueued: Int): Stream[F, Notification[String]]
 
   /**
    * Signal representing the current state of all Postgres configuration variables announced to this
@@ -211,7 +211,7 @@ object Protocol {
         implicit val na: Namer[F] = nam
         implicit val ExchangeF: protocol.Exchange[F] = ex
 
-        override def notifications(maxQueued: Int): Stream[F, Notification] =
+        override def notifications(maxQueued: Int): Stream[F, Notification[String]] =
           bms.notifications(maxQueued)
 
         override def parameters: Signal[F, Map[String, String]] =

--- a/modules/core/src/main/scala/net/message/NotificationResponse.scala
+++ b/modules/core/src/main/scala/net/message/NotificationResponse.scala
@@ -8,7 +8,7 @@ import scodec.Decoder
 import scodec.codecs._
 import skunk.data.Notification
 
-case class NotificationResponse(value: Notification) extends BackendMessage
+case class NotificationResponse(value: Notification[String]) extends BackendMessage
 
 object NotificationResponse {
   final val Tag = 'A'

--- a/modules/docs/src/main/paradox/index.md
+++ b/modules/docs/src/main/paradox/index.md
@@ -30,6 +30,7 @@ Skunk is published for Scala $scala-versions$ and can be included in your projec
 
 Prerequisites:
 
+- We assume you are comfortable with Postgres.
 - We assume you are comfortable with [cats](http://typelevel.org/cats/), [cats-effect](https://typelevel.org/cats-effect/), and [fs2](https://fs2.io).
 - If not, give it a try anyway! If you run into trouble the linked websites have many learning resources.
 

--- a/modules/docs/src/main/paradox/tutorial/Channels.md
+++ b/modules/docs/src/main/paradox/tutorial/Channels.md
@@ -19,16 +19,15 @@ See [`NOTIFY`](https://www.postgresql.org/docs/10/sql-notify.html) and [`LISTEN`
 Use the `channel` method on `Session` to construct a channel.
 
 ```scala mdoc:compile-only
-// assume s:Session[IO]
+// assume s: Session[IO]
 val ch = s.channel(id"my_channel") // Channel[IO, String, String]
 ```
 
 Observe the following:
 
 - The argument to `channel` is an `Identifier`. See @ref:[Identifiers](../reference/Identifiers.md) for more information.
-- `ch` is a `Channel` which can consumes `String`s and emits `Notification[String]`s. A notification is a structure that includes the process ID and channel identifier as well as the payload.
+- `ch` is a `Channel` which consumes `String`s and emits `Notification[String]`s. A notification is a structure that includes the process ID and channel identifier as well as the payload.
 - `Channel` is a profunctor and thus can be contramapped to change the input type, and mapped to change the output type.
-- Constructing a `Channel` does not actually "do" anything immediately.
 
 ## Listening to a Channel
 
@@ -42,11 +41,13 @@ val nbs = ch.listen(1024) // Stream[IO, Notification[String]]
 Observe the following:
 
 - The argument to `listen` is the maximum number of messages that will be enqueued before blocking the underlying socket. If you run the resulting stream be sure to process notifications in a timely manner to avoid blocking concurrent session operations.
-- When `nbs` begins execution it will first issue a `LISTEN <channel>`.
+- When `nbs` begins execution it will first issue `LISTEN <channel>`.
 - While `nbs` is executing it will emit any messages received from `<channel>`.
 - When `nbs` terminates it will issue `UNLISTEN <channel>`.
 
 It is perfectly fine to run such a stream concurrently while the underlying session is being used for other things (modulo transaction and fiber lifetime concerns; see @ref:[Transactions](Transactions.md) and @ref:[Concurrency.md](../reference/Concurrency.md) for more information).
+
+If you wish to listen to all notifications on all subscribed channels, use the `notifications` method on `Session`.
 
 ## Notifying a Channel
 
@@ -60,8 +61,7 @@ ch.notify("hello") // IO[Unit]
 Every `Channel` is also an fs2 `Pipe` that consumes messages.
 
 ```scala mdoc:compile-only
-// assume s:Session[IO]
-
+// assume s: Session[IO]
 // select all the country names and stream them to the country_names channel.
 s.prepare(sql"select name from country".query(varchar)).use { ps =>
   ps.stream(Void, 512)

--- a/modules/docs/src/main/paradox/tutorial/Channels.md
+++ b/modules/docs/src/main/paradox/tutorial/Channels.md
@@ -1,14 +1,74 @@
+```scala mdoc:invisible
+import cats.effect._
+import cats.implicits._
+import skunk._
+import skunk.implicits._
+import skunk.codec.all._
+import natchez.Trace.Implicits.noop
+val s: Session[IO] = null
+val ch: Channel[IO, String, String] = null
+```
 # Channels
 
-... introduce channels
+Skunk provides high-level support for Postgres channels, exposing them as an fs2 `Pipe` / `Stream` pair.
 
-## Simple Channel Example
+See [`NOTIFY`](https://www.postgresql.org/docs/10/sql-notify.html) and [`LISTEN`](https://www.postgresql.org/docs/10/sql-listen.html) in the PostgreSQL documentation for an explanation of channel operations. The text that follows assumes you have a working knowledge of the information in those sections.
 
-read from a channel, write to it using psql
+## Constructing a Channel
 
-## Transactional Behavior
+Use the `channel` method on `Session` to construct a channel.
 
-example code that shows we only get notifications when transactions commit
+```scala mdoc:compile-only
+// assume s:Session[IO]
+val ch = s.channel(id"my_channel") // Channel[IO, String, String]
+```
 
-## Experiment
+Observe the following:
 
+- The argument to `channel` is an `Identifier`. See @ref:[Identifiers](../reference/Identifiers.md) for more information.
+- `ch` is a `Channel` which can consumes `String`s and emits `Notification[String]`s. A notification is a structure that includes the process ID and channel identifier as well as the payload.
+- `Channel` is a profunctor and thus can be contramapped to change the input type, and mapped to change the output type.
+- Constructing a `Channel` does not actually "do" anything immediately.
+
+## Listening to a Channel
+
+To listen on a channel, construct a stream via `.listen`.
+
+```scala mdoc:compile-only
+// assume ch: Channel[IO, String, String]
+val nbs = ch.listen(1024) // Stream[IO, Notification[String]]
+```
+
+Observe the following:
+
+- The argument to `listen` is the maximum number of messages that will be enqueued before blocking the underlying socket. If you run the resulting stream be sure to process notifications in a timely manner to avoid blocking concurrent session operations.
+- When `nbs` begins execution it will first issue a `LISTEN <channel>`.
+- While `nbs` is executing it will emit any messages received from `<channel>`.
+- When `nbs` terminates it will issue `UNLISTEN <channel>`.
+
+It is perfectly fine to run such a stream concurrently while the underlying session is being used for other things (modulo transaction and fiber lifetime concerns; see @ref:[Transactions](Transactions.md) and @ref:[Concurrency.md](../reference/Concurrency.md) for more information).
+
+## Notifying a Channel
+
+Use `.notify` to send a message to a channel.
+
+```scala mdoc:compile-only
+// assume ch: Channel[IO, String, String]
+ch.notify("hello") // IO[Unit]
+```
+
+Every `Channel` is also an fs2 `Pipe` that consumes messages.
+
+```scala mdoc:compile-only
+// assume s:Session[IO]
+
+// select all the country names and stream them to the country_names channel.
+s.prepare(sql"select name from country".query(varchar)).use { ps =>
+  ps.stream(Void, 512)
+    .through(s.channel(id"country_names"))
+    .compile
+    .drain
+}
+```
+
+Keep in mind (as detailed in the documentation for [`NOTIFY`](https://www.postgresql.org/docs/10/sql-notify.html)) that notifications performed inside a transaction are not delivered until the transaction commits. Notifications performed outside a transaction are delivered immediately.

--- a/modules/docs/src/main/paradox/tutorial/Command.md
+++ b/modules/docs/src/main/paradox/tutorial/Command.md
@@ -5,6 +5,7 @@ import skunk._
 import skunk.implicits._
 import skunk.codec.all._
 import natchez.Trace.Implicits.noop
+import fs2.Stream
 val s: Session[IO] = null
 ```
 
@@ -83,6 +84,15 @@ If we're slighly more clever we can do this with `traverse` and return a list of
 s.prepare(c).use { pc =>
   List("xyzzy", "fnord", "blech").traverse(s => pc.execute(s))
 } // IO[List[Completion]]
+```
+
+And if we're yet more clever we can turn `pc` into an fs2 `Pipe`.
+
+```scala mdoc:compile-only
+// assume s: Session[IO]
+Stream.resource(s.prepare(c)).flatMap { pc =>
+  Stream("xyzzy", "fnord", "blech").through(pc.pipe)
+} // Stream[IO, Completion]
 ```
 
 ### Contramapping Commands

--- a/modules/docs/src/main/paradox/tutorial/Query.md
+++ b/modules/docs/src/main/paradox/tutorial/Query.md
@@ -185,14 +185,15 @@ stream.compile.drain // IO[Unit]
 
 This program does the same thing, but perhaps in a more convenient style.
 
-@scaladoc[PreparedQuery](skunk.PreparedQuery) provides the following methods for execution. See the Scaladoc for more information.
+@scaladoc[PreparedQuery[A, B]](skunk.PreparedQuery) provides the following methods for execution. See the Scaladoc for more information.
 
 | Method    | Return Type                | Notes                                             |
 |-----------|----------------------------|---------------------------------------------------|
-| `stream`  | `Stream[F,A]`              | All results, as a stream.                         |
-| `option`  | `F[Option[A]]`             | Zero or one result, otherwise an error is raised. |
-| `unique`  | `F[A]`                     | Exactly one result, otherwise an error is raised. |
-| `cursor`  | `Resource[F,Cursor[F,A]]`  | A cursor that returns pages of results.           |
+| `stream`  | `Stream[F,B]`              | All results, as a stream.                         |
+| `option`  | `F[Option[B]]`             | Zero or one result, otherwise an error is raised. |
+| `unique`  | `F[B]`                     | Exactly one result, otherwise an error is raised. |
+| `cursor`  | `Resource[F,Cursor[F,B]]`  | A cursor that returns pages of results.           |
+| `pipe`    | `Pipe[F, A, B]`            | A pipe that executes the query for each input value, concatenating the results. |
 
 ## Multi-Parameter Query
 

--- a/modules/docs/src/main/paradox/tutorial/Transactions.md
+++ b/modules/docs/src/main/paradox/tutorial/Transactions.md
@@ -82,6 +82,10 @@ Transaction finalization is summarized in the following matrix.
 | **Active** | commit | roll back | roll back, re-raise |
 | **Error**  | roll back | roll back | roll back, re-raise |
 
+## Transaction Characteristics
+
+To specify a non-default isolation level (or other transaction characteristics) execute a [`SET TRANSACTION`](https://www.postgresql.org/docs/10/sql-set-transaction.html) command as the first operation inside your transaction. A future version of Skunk might make this more ergonomic.
+
 ## Full Example
 
 Here is a complete program listing that demonstrates our knowledge thus far.

--- a/modules/tests/src/test/scala/ChannelTest.scala
+++ b/modules/tests/src/test/scala/ChannelTest.scala
@@ -18,11 +18,11 @@ case object ChannelTest extends SkunkTest {
     val data = List("foo", "bar", "baz")
     val ch0 = s.channel(id"channel_test")
     val ch1 = ch0.mapK(FunctionK.id)
-    val ch2 = Functor[Channel[IO, String, ?]].map(ch1)(_.value)
+    val ch2 = Functor[Channel[IO, String, ?]].map(ch1)(identity[String])
     val ch3 = Contravariant[Channel[IO, ?, String]].contramap(ch2)(identity[String])
     val ch  = Profunctor[Channel[IO, ?, ?]].dimap(ch3)(identity[String])(identity[String])
     for {
-      f <- ch.listen(42).takeThrough(_ != data.last).compile.toList.start
+      f <- ch.listen(42).map(_.value).takeThrough(_ != data.last).compile.toList.start
       _ <- data.traverse_(ch.notify)
       d <- f.join
       _ <- assert(s"channel data $d $data", data.endsWith(d)) // we may miss the first few

--- a/modules/tests/src/test/scala/simulation/SimTest.scala
+++ b/modules/tests/src/test/scala/simulation/SimTest.scala
@@ -34,7 +34,7 @@ trait SimTest extends FTest with SimMessageSocket.DSL {
     def transactionStatus: Signal[IO,TransactionStatus] = ???
     def parameters: Signal[IO,Map[String,String]] = ???
     def backendKeyData: Deferred[IO,BackendKeyData] = ???
-    def notifications(maxQueued: Int): fs2.Stream[IO,Notification] = ???
+    def notifications(maxQueued: Int): fs2.Stream[IO, Notification[String]] = ???
     def terminate: IO[Unit] = ???
   }
 


### PR DESCRIPTION
- gets the transaction doc to a reasonable state
- adds channel doc
- when working on channel doc it was obvious that the parameterization was wrong, so fixed that by making `Notification` itself parameterized, and the `Channel` covariant bits delegate to that.
- also noticed that `Channel` should be a `Pipe`, and by that reasoning so should `PreparedCommand` and `PreparedQuery`, so changed those as well.
- need to add tests for this (coverage is going to drop)