### PR TITLE
make temporal codecs immune to locale

### DIFF
--- a/modules/core/src/main/scala/codec/TemporalCodecs.scala
+++ b/modules/core/src/main/scala/codec/TemporalCodecs.scala
@@ -18,6 +18,7 @@ import skunk.data.Type
 import java.time.temporal.TemporalAccessor
 import java.time.format.DateTimeFormatterBuilder
 import java.time.Duration
+import java.util.Locale
 
 trait TemporalCodecs {
 
@@ -49,7 +50,7 @@ trait TemporalCodecs {
         .optionalEnd
     }
 
-    requiredPart.toFormatter
+    requiredPart.toFormatter(Locale.US)
 
   }
 
@@ -62,7 +63,7 @@ trait TemporalCodecs {
       .appendValue(MONTH_OF_YEAR, 2)
       .appendLiteral('-')
       .appendValue(DAY_OF_MONTH, 2)
-      .toFormatter
+      .toFormatter(Locale.US)
 
   private val eraFormatter: DateTimeFormatter =
     DateTimeFormatter.ofPattern(" G")
@@ -71,7 +72,7 @@ trait TemporalCodecs {
     new DateTimeFormatterBuilder()
       .append(localDateFormatterWithoutEra)
       .appendOptional(eraFormatter)
-      .toFormatter
+      .toFormatter(Locale.US)
 
   private def localDateTimeFormatter(precision: Int): DateTimeFormatter =
     new DateTimeFormatterBuilder()
@@ -79,7 +80,7 @@ trait TemporalCodecs {
       .appendLiteral(' ')
       .append(timeFormatter(precision))
       .appendOptional(eraFormatter)
-      .toFormatter
+      .toFormatter(Locale.US)
 
   // If the offset is only hours, postgres will return time like this: "12:40:50+13"
   // We need to provide a custom offset format to parse this with DateTimeFormatter
@@ -87,7 +88,7 @@ trait TemporalCodecs {
     new DateTimeFormatterBuilder()
       .append(timeFormatter(precision))
       .appendOffset("+HH:mm", "")
-      .toFormatter
+      .toFormatter(Locale.US)
 
   private def offsetDateTimeFormatter(precision: Int): DateTimeFormatter =
     new DateTimeFormatterBuilder()
@@ -96,7 +97,7 @@ trait TemporalCodecs {
       .append(timeFormatter(precision))
       .appendOffset("+HH:mm", "")
       .appendOptional(eraFormatter)
-      .toFormatter
+      .toFormatter(Locale.US)
 
   val date: Codec[LocalDate] =
     temporal(localDateFormatter, LocalDate.parse, Type.date)

--- a/modules/tests/src/test/scala/issue/231.scala
+++ b/modules/tests/src/test/scala/issue/231.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package tests.issue
+
+import cats.implicits._
+import ffstest.FTest
+import java.util.Locale
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import skunk.codec.temporal.timestamptz
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+// https://github.com/tpolecat/skunk/issues/231
+case object Test231 extends FTest {
+
+  val es_CO: Locale =
+    Locale.getAvailableLocales().find(_.toString == "es_CO").getOrElse(sys.error("Cannot find es_CO locale."))
+
+  val ts: OffsetDateTime =
+    OffsetDateTime.of(LocalDateTime.of(2020, 1, 1, 12, 30, 0), ZoneOffset.ofHours(6))
+
+  def inColombia[A](a: => A): A = {
+    val prev = Locale.getDefault()
+    try { Locale.setDefault(es_CO); a } finally Locale.setDefault(prev)
+  }
+
+  test("'G' formatter expands to 'anno Dómini' if the Locale is set to es_CO") {
+    inColombia {
+      assertEqual("era", DateTimeFormatter.ofPattern("G").format(ts), "anno Dómini")
+    }
+  }
+
+  test("timestamptz formatter is independent of Locale") {
+    inColombia {
+      assertEqual("timestamptz", timestamptz.encode(ts).head.get, "2020-01-01 12:30:00+06 AD")
+    }
+  }
+
+}


### PR DESCRIPTION
A user discovered that temporal codecs with an era as part of their format don't work in some locales (`es_CO` specifically but there are likely others). This fixes the locale to `Locale.US` in the `DateTimeFormatters` used by the codecs, which should be ok because we're fixing the date style to `ISO, MDY` during session startup and have declared in the doc that if you change it you're in trouble.