### PR TITLE
Fix paradox generated documentation by replacing target/mdoc with src/main/paradox

### DIFF
--- a/modules/docs/src/main/paradox/_template/js/link_fix.js
+++ b/modules/docs/src/main/paradox/_template/js/link_fix.js
@@ -1,0 +1,3 @@
+function sourceUrlFix(sourceUrl) {
+    $("#source-link").attr("href", sourceUrl.replace("target/mdoc", "src/main/paradox"))
+}

--- a/modules/docs/src/main/paradox/_template/source.st
+++ b/modules/docs/src/main/paradox/_template/source.st
@@ -1,0 +1,9 @@
+<script type="text/javascript" src="$page.base$js/link_fix.js"></script>
+
+$if(page.source_url)$
+<div class="source-github">
+The source code for this page can be found <a id="source-link" href="$page.source_url$">here</a>.
+</div>
+$endif$
+
+<script type="text/javascript">jQuery(function(){sourceUrlFix('$page.source_url$')});</script>


### PR DESCRIPTION
Fixes #240 