### PR TITLE
Contributing Guide v0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ project/hydra.sbt
 .classpath
 .project
 .worksheet/
-bin/
 .settings/
 
 # OS X

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing Guide
+
+## Testing
+
+Ensure you are not running a local postgres server (such as the Postgres app for OSX).
+
+Start up / tear down the local network:
+
+```bash
+> ./bin/local up
+> ./bin/local down
+```
+
+Then to run all the tests, in a separate window:
+
+```bash
+> sbt test
+```
+
+To run a specific test:
+
+```bash
+> sbt
+> test:testOnly tests.simulation.StartupSimTest
+```

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ Skunk is a data access library for Scala + Postgres.
 Please proceed to the [microsite](http://tpolecat.github.io/skunk) for more information.
 
 Please drop a :star: if this project interests you. I need encouragement.
+
+To contribute, see the [contributing guide](./CONTRIBUTING.md).

--- a/bin/local
+++ b/bin/local
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu
+
+DIR=$1
+
+print_usage() {
+  printf "\nUsage:\n \
+    ./bin/local <stack_direction>\n
+    Example:\n
+      ./bin/local up \n
+      ./bin/local down \n\n"
+}
+
+case $DIR in
+  "up") CMD="up -d";;
+  "down") CMD="down";;
+  *)
+    print_usage
+    exit 1
+  ;;
+esac
+
+# Fix postgres ssl key permissions.
+chmod 600 world/server.key
+
+docker-compose $CMD


### PR DESCRIPTION
Follow up from some conversations in Gitter. I started a contributing guide (`CONTRIBUTING.md`) and added a pointer in the README. I also added a start up script to make things a bit easier.

Let me know what else you'd like to see in the contributing guide! I also removed the `./bin` directory from the gitignore. It's a habit to put these kinds of scripts in `bin`, but I am happy to put it where ever you think would be most convenient.

Start up script:

```bash
skunk :>./bin/local asdf

Usage:
     ./bin/local <stack_direction>

    Example:

      ./bin/local up

      ./bin/local down

skunk :>./bin/local up
Creating network "skunk_default" with the default driver
Creating skunk_postgres_1 ... done
Creating skunk_jaeger_1   ... done
Creating skunk_scram_1    ... done
Creating skunk_trust_1    ... done
skunk :>./bin/local down
Stopping skunk_postgres_1 ... done
Stopping skunk_trust_1    ... done
Stopping skunk_scram_1    ... done
Stopping skunk_jaeger_1   ... done
Removing skunk_postgres_1 ... done
Removing skunk_trust_1    ... done
Removing skunk_scram_1    ... done
Removing skunk_jaeger_1   ... done
Removing network skunk_default
```