### PR TITLE
Make tutorial more Scala-newbie friendly

### DIFF
--- a/modules/docs/src/main/paradox/tutorial/Setup.md
+++ b/modules/docs/src/main/paradox/tutorial/Setup.md
@@ -32,8 +32,10 @@ import skunk._
 import skunk.implicits._
 import skunk.codec.all._
 import natchez.Trace.Implicits.noop                          // (1)
+import scala.concurrent.ExecutionContext
 
 object Hello extends IOApp {
+  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   val session: Resource[IO, Session[IO]] =
     Session.single(                                          // (2)


### PR DESCRIPTION
It takes about 15mins for me to determine the reason for the following error:

```
Could not find an instance of Concurrent for cats.effect.IO.
I found:

    cats.effect.IO.ioConcurrentEffect(
      /* missing */summon[cats.effect.ContextShift[cats.effect.IO]]
    )

But no implicit values were found that match type cats.effect.ContextShift[cats.effect.IO].

One of the following imports might make progress towards fixing the problem:

  import shapeless.~?>.idKeyWitness
  import shapeless.~?>.idValueWitness
  import shapeless.~?>.witness


  )
```

Thanks for your work! 👍