### PR TITLE
Fix _float4 and _float8 Codecs to work on arrays not primitive values

### DIFF
--- a/modules/core/src/main/scala/codec/NumericCodecs.scala
+++ b/modules/core/src/main/scala/codec/NumericCodecs.scala
@@ -28,8 +28,8 @@ trait NumericCodecs {
   val _int4: Codec[Arr[Int]]   = Codec.array(_.toString, safe(_.toInt),   Type._int4)
   val _int8: Codec[Arr[Long]]  = Codec.array(_.toString, safe(_.toLong),  Type._int8)
   val _numeric: Codec[Arr[BigDecimal]] = Codec.array(_.toString, safe(BigDecimal(_)), Type._numeric)
-  val _float4: Codec[Float]   = Codec.simple(_.toString, safe(_.toFloat), Type._float4)
-  val _float8: Codec[Double]  = Codec.simple(_.toString, safe(_.toDouble), Type._float8)
+  val _float4: Codec[Arr[Float]]   = Codec.array(_.toString, safe(_.toFloat), Type._float4)
+  val _float8: Codec[Arr[Double]]  = Codec.array(_.toString, safe(_.toDouble), Type._float8)
 
 }
 


### PR DESCRIPTION
Seemed like one those pesky copy + paste oversights.