### PR TITLE
handle broken socket

### DIFF
--- a/modules/core/src/main/scala/exception/EofException.scala
+++ b/modules/core/src/main/scala/exception/EofException.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.exception
+
+case class EofException(bytesRequested: Int, bytesRead: Int) extends SkunkException(
+  sql       = None,
+  message   = "EOF was reached on the network socket.",
+  detail    = Some(s"Attempt to read $bytesRequested byte(s) failed after $bytesRead bytes(s) were read, because the connection had closed."),
+  hint      = Some(s"Discard this session and retry with a new one."),
+  sqlOrigin = None,
+)

--- a/modules/core/src/main/scala/net/AbstractMessageSocket.scala
+++ b/modules/core/src/main/scala/net/AbstractMessageSocket.scala
@@ -9,7 +9,6 @@ import skunk.util.Origin
 import cats.effect.Concurrent
 import cats.syntax.all._
 import skunk.exception.ProtocolError
-import skunk.net.BufferedMessageSocket.NetworkError
 
 abstract class AbstractMessageSocket[F[_]: Concurrent]
   extends MessageSocket[F] {
@@ -17,10 +16,7 @@ abstract class AbstractMessageSocket[F[_]: Concurrent]
   override def expect[B](f: PartialFunction[BackendMessage, B])(implicit or: Origin): F[B] =
     receive.flatMap { m =>
       if (f.isDefinedAt(m)) f(m).pure[F]
-      else m match {
-        case NetworkError(t) => Concurrent[F].raiseError(t)
-        case m => Concurrent[F].raiseError(new ProtocolError(m, or))
-      }
+      else Concurrent[F].raiseError(new ProtocolError(m, or))
     }
 
   override def flatExpect[B](f: PartialFunction[BackendMessage, F[B]])(implicit or: Origin): F[B] =

--- a/modules/core/src/main/scala/net/BitVectorSocket.scala
+++ b/modules/core/src/main/scala/net/BitVectorSocket.scala
@@ -13,6 +13,7 @@ import scala.concurrent.duration.FiniteDuration
 import scodec.bits.BitVector
 import java.net.InetSocketAddress
 import fs2.io.tcp.SocketGroup
+import skunk.exception.EofException
 
 /** A higher-level `Socket` interface defined in terms of `BitVector`. */
 trait BitVectorSocket[F[_]] {
@@ -48,10 +49,10 @@ object BitVectorSocket {
 
       def readBytes(n: Int): F[Array[Byte]] =
         socket.readN(n, Some(readTimeout)).flatMap {
-          case None => ev.raiseError(new Exception("Fatal: EOF"))
+          case None => ev.raiseError(EofException(n, 0))
           case Some(c) =>
             if (c.size == n) c.toArray.pure[F]
-            else ev.raiseError(new Exception(s"Fatal: Read ${c.size} bytes, expected $n."))
+            else ev.raiseError(EofException(n, c.size))
         }
 
       override def read(nBytes: Int): F[BitVector] =

--- a/modules/core/src/main/scala/net/BufferedMessageSocket.scala
+++ b/modules/core/src/main/scala/net/BufferedMessageSocket.scala
@@ -129,6 +129,7 @@ object BufferedMessageSocket {
     queueSize: Int
   ): F[BufferedMessageSocket[F]] =
     for {
+      term  <- Ref[F].of[Option[Throwable]](None) // terminal error
       queue <- Queue.bounded[F, BackendMessage](queueSize)
       xaSig <- SignallingRef[F, TransactionStatus](TransactionStatus.Idle) // initial state (ok)
       paSig <- SignallingRef[F, Map[String, String]](Map.empty)
@@ -141,8 +142,23 @@ object BufferedMessageSocket {
     } yield
       new AbstractMessageSocket[F] with BufferedMessageSocket[F] {
 
-        override def receive: F[BackendMessage] = queue.dequeue1
-        override def send(message: FrontendMessage): F[Unit] = ms.send(message)
+        // n.b. there is a race condition here, prevented by the protocol semaphore
+        override def receive: F[BackendMessage] =
+          term.get.flatMap {
+            case Some(t) => Concurrent[F].raiseError(t)
+            case None    =>
+              queue.dequeue1.flatMap {
+                case e: NetworkError => term.set(Some(e.cause)) *> receive
+                case m               => m.pure[F]
+              }
+          }
+
+        override def send(message: FrontendMessage): F[Unit] =
+          term.get.flatMap {
+            case Some(t) => Concurrent[F].raiseError(t)
+            case None    => ms.send(message)
+          }
+
         override def transactionStatus: SignallingRef[F, TransactionStatus] = xaSig
         override def parameters: SignallingRef[F, Map[String, String]] = paSig
         override def backendKeyData: Deferred[F, BackendKeyData] = bkSig
@@ -152,14 +168,17 @@ object BufferedMessageSocket {
 
         override protected def terminate: F[Unit] =
           fib.cancel *>      // stop processing incoming messages
-          ms.send(Terminate) // server will close the socket when it sees this
+          send(Terminate) // server will close the socket when it sees this
 
         override def history(max: Int): F[List[Either[Any, Any]]] =
           ms.history(max)
 
       }
 
-  case class NetworkError(cause: Throwable) extends BackendMessage
+  // A poison pill that we place in the message queue to indicate that we're in a fatal error
+  // condition, message processing has stopped, and any further attempts to send or receive should
+  // result in `cause` being raised.
+  private case class NetworkError(cause: Throwable) extends BackendMessage
 
 }
 

--- a/modules/core/src/main/scala/net/MessageSocket.scala
+++ b/modules/core/src/main/scala/net/MessageSocket.scala
@@ -53,6 +53,8 @@ object MessageSocket {
             val (tag, len) = header.decodeValue(bits).require
             val decoder    = BackendMessage.decoder(tag)
             bvs.read(len - 4).map(decoder.decodeValue(_).require)
+          } .onError {
+            case t => Sync[F].delay(println(s" ← ${Console.RED}${t.getMessage}${Console.RESET}")).whenA(debug)
           }
         }
 

--- a/modules/docs/src/main/paradox/reference/Sessions.md
+++ b/modules/docs/src/main/paradox/reference/Sessions.md
@@ -68,11 +68,24 @@ It is possible to modify default session parameters via the parameters session p
 
 ```scala mdoc:compile-only
 Session.single[IO](
-  host     = "localhost",
-  user     = "jimmy",
-  database = "world",
-  password = Some("banana"),
-  port = 5439,
+  host       = "localhost",
+  user       = "jimmy",
+  database   = "world",
+  password   = Some("banana"),
+  port       = 5439,
   parameters = Session.DefaultConnectionParameters - "IntervalStyle"
 )
 ```
+
+## Error Conditions
+
+A `Session` is ultimately a TCP Socket, and as such a number of error conditions can arise. These conditions immediately invalidate the session and raise exceptions in your effect type `F`, with the expectation that the operation will fail, or will perhaps be retried with a new session.
+
+| Condition | Exception | Meaning |
+|-----------|----|---|
+| Connect&nbsp;Timeout | TBD | TBD - The connect timeout expired before a connection can be established with the Postgres server. |
+| Protocol&nbsp;Timeout | TBD | TBD - The protocol timeout expired before receiving an expected response from the Postgres server. |
+| Disconnection | `EofException` | The underlying socket has been closed. |
+
+Note that if you wish to **limit statement execution time**, it's best to use the `statement_timeout` session parameter (settable via SQL or via `parameters` above), which will raise a server-side exception on expiration and will _not_ invalidate the session.
+

--- a/modules/tests/src/test/scala/DisconnectTest.scala
+++ b/modules/tests/src/test/scala/DisconnectTest.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2018-2020 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package tests
+
+import skunk.implicits._
+import skunk.codec.all._
+import cats.effect._
+import skunk.Session
+import natchez.Trace.Implicits.noop
+import skunk.exception.EofException
+import ffstest.FTest
+
+class DisconnectTest extends FTest {
+
+  val pool: Resource[IO, Resource[IO, Session[IO]]] =
+    Session.pooled(
+      host     = "localhost",
+      port     = 5432,
+      user     = "jimmy",
+      database = "world",
+      password = Some("banana"),
+      max      = 1, // ensure that the session is reused if possible
+      // debug = true,
+    )
+
+  test("disconnect/reconnect") {
+    pool.use { p =>
+      p.use { s => // this session will be invalidated
+        s.execute(sql"select pg_terminate_backend(pg_backend_pid())".query(bool))
+      }.assertFailsWith[EofException] *>
+      p.use { s => // this should be a *new* session, since the old one was busted
+        s.execute(sql"select 1".query(int4))
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Skunk was unable to handle a closed socket correctly, resulting in #383 and #384. It now raises `EofException` in this case, and re-raises it on any subsequent attempts to send or receive messages on the `Session`.

Note that the socket read timeout really needs to be infinite because the polling loop needs to handle asynchronous messages. Instead we need a userland timeout that works on `BufferedMessageSocket` and places a timeout on dequeue operations (#387).