### PR TITLE
Narrow sql interpolator return type to Fragment

### DIFF
--- a/modules/core/src/main/scala-2/syntax/StringContextOps.scala
+++ b/modules/core/src/main/scala-2/syntax/StringContextOps.scala
@@ -14,7 +14,7 @@ import skunk.util.Origin
 
 class StringContextOps private[skunk](sc: StringContext) {
 
-  def sql(argSeq: Any*): Any =
+  def sql(argSeq: Any*): Fragment[_] =
     macro StringContextOps.StringOpsMacros.sql_impl
 
   def id(): Identifier =

--- a/modules/core/src/main/scala-3/syntax/StringContextOps.scala
+++ b/modules/core/src/main/scala-3/syntax/StringContextOps.scala
@@ -49,7 +49,7 @@ object StringContextOps {
 
   def yell(s: String) = println(s"${Console.RED}$s${Console.RESET}")
 
-  def sqlImpl(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qc:Quotes): Expr[Any] = {
+  def sqlImpl(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qc:Quotes): Expr[Fragment[?]] = {
     import qc.reflect.report
 
     // Ok we want to construct an Origin here
@@ -154,7 +154,7 @@ object StringContextOps {
 
 trait ToStringContextOps {
 
-  extension (inline sc: StringContext) transparent inline def sql(inline args: Any*): Any =
+  extension (inline sc: StringContext) transparent inline def sql(inline args: Any*): Fragment[?] =
     ${ StringContextOps.sqlImpl('sc, 'args) }
 
   extension (inline sc: StringContext) inline def id(): Identifier =

--- a/modules/docs/src/main/scala/mdoc/Main.scala
+++ b/modules/docs/src/main/scala/mdoc/Main.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 by Rob Norris
+// Copyright (c) 2018-2021 by Rob Norris
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 


### PR DESCRIPTION
Improves Intellij support, although doesn't eliminate all red
squiggles because we don't know statically the type of `Fragment`.