### PR TITLE
re-enable stacktraces, move message from toString to getMessage

### DIFF
--- a/modules/core/src/main/scala/exception/SkunkException.scala
+++ b/modules/core/src/main/scala/exception/SkunkException.scala
@@ -22,7 +22,7 @@ class SkunkException protected[skunk](
   val sqlOrigin:       Option[Origin]               = None,
   val argumentsOrigin: Option[Origin]               = None,
   val callSite:        Option[CallSite]             = None
-) extends Exception(message) with Fields with scala.util.control.NoStackTrace {
+) extends Exception(message) with Fields {
 
   override def fields: Map[String, TraceValue] = {
 
@@ -118,7 +118,7 @@ class SkunkException protected[skunk](
   protected def sections: List[String] =
     List(header, statement, args) //, exchanges)
 
-  final override def toString =
+  final override def getMessage =
     sections
       .combineAll
       .linesIterator


### PR DESCRIPTION
This moves the text of exception messages to `getMessage` so they'll be reported correctly by MUnit. Also re-enables stacktraces since they're not quite as useless with CE3.

resolves #253 