### PR TITLE
Set TCP_NODELAY

### DIFF
--- a/modules/core/shared/src/main/scala/net/BitVectorSocket.scala
+++ b/modules/core/shared/src/main/scala/net/BitVectorSocket.scala
@@ -9,7 +9,7 @@ import cats.effect._
 import cats.syntax.all._
 import fs2.Chunk
 import scodec.bits.BitVector
-import fs2.io.net.{ Socket, SocketGroup }
+import fs2.io.net.{Socket, SocketGroup, SocketOption}
 import com.comcast.ip4s._
 import skunk.exception.EofException
 
@@ -67,7 +67,7 @@ object BitVectorSocket {
     sslOptions:   Option[SSLNegotiation.Options[F]],
   )(implicit ev: MonadError[F, Throwable]): Resource[F, BitVectorSocket[F]] =
     for {
-      sock  <- sg.client(SocketAddress(Hostname.fromString(host).get, Port.fromInt(port).get)) // TODO
+      sock  <- sg.client(SocketAddress(Hostname.fromString(host).get, Port.fromInt(port).get), List(SocketOption.noDelay(true))) // TODO
       sockʹ <- sslOptions.fold(sock.pure[Resource[F, *]])(SSLNegotiation.negotiateSSL(sock, _))
     } yield fromSocket(sockʹ)
 


### PR DESCRIPTION
We have faced the same issue as described here: https://github.com/tpolecat/skunk/issues/450
I propose to set this option, it avoids a 40ms penalty in each round trip to the server.

btw, would you also take an identical PR for the 0.0.x branch ?
Thanks

fixes #450 