### PR TITLE
Implement AuthenticationCleartextPassword

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,17 @@ services:
       POSTGRES_PASSWORD: banana
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
+  # for testing clear-text password login
+  password:
+    image: postgres:11
+    ports:
+      - 5435:5432
+    environment:
+      POSTGRES_DB: world
+      POSTGRES_USER: jimmy
+      POSTGRES_PASSWORD: banana
+      POSTGRES_HOST_AUTH_METHOD: password
+      POSTGRES_INITDB_ARGS: --auth-host=password
   # for testing redshift connections
   redshift:
     image: guildeducation/docker-amazon-redshift

--- a/modules/core/shared/src/main/scala/exception/UnsupportedAuthenticationSchemeException.scala
+++ b/modules/core/shared/src/main/scala/exception/UnsupportedAuthenticationSchemeException.scala
@@ -12,7 +12,7 @@ class UnsupportedAuthenticationSchemeException(
   sql = None,
   message = s"Unsupported authentication scheme.",
   hint = Some(
-    s"""|The server requested `$message`, but Skunk currently only supports `trust` and `password` (md5 and scram-sha-256).
+    s"""|The server requested `$message`, but Skunk currently only supports `trust`, `password`, `md5` and `scram-sha-256`.
         |""".stripMargin
   )
 )

--- a/modules/core/shared/src/main/scala/net/message/PasswordMessage.scala
+++ b/modules/core/shared/src/main/scala/net/message/PasswordMessage.scala
@@ -16,4 +16,7 @@ object PasswordMessage extends PasswordMessagePlatform {
   val encoder: Encoder[PasswordMessage] =
     utf8z.contramap[PasswordMessage](_.password)
 
+  def cleartext(password: String): PasswordMessage =
+    new PasswordMessage(password) {}
+
 }

--- a/modules/docs/src/main/paradox/reference/Sessions.md
+++ b/modules/docs/src/main/paradox/reference/Sessions.md
@@ -13,7 +13,7 @@ TBD - talk about pooling, session lifecycle, cleanup, etc.
 
 ## Authentication
 
-Skunk currently supports the **trust** (no password necessary) and **password** (`md5` and `scram-sha-256` only) authentication methods.
+Skunk currently supports the `trust` (no password necessary), `password`, `md5` and `scram-sha-256` authentication methods.
 
 See [§20.3](https://www.postgresql.org/docs/current/auth-methods.html) in the Postgres documentation for more information on authentication methods.
 

--- a/modules/tests/shared/src/test/scala/StartupTest.scala
+++ b/modules/tests/shared/src/test/scala/StartupTest.scala
@@ -16,10 +16,11 @@ class StartupTest extends ffstest.FTest {
 
   // Different ports for different authentication schemes.
   object Port {
-    val Invalid = 5431
-    val MD5     = 5432
-    val Trust   = 5433
-    val Scram   = 5434
+    val Invalid  = 5431
+    val MD5      = 5432
+    val Trust    = 5433
+    val Scram    = 5434
+    val Password = 5435
   }
 
   test("md5 - successful login") {
@@ -175,6 +176,64 @@ class StartupTest extends ffstest.FTest {
       database = "world",
       password = Some("apple"),
       port     = Port.Scram,
+    ).use(_ => IO.unit)
+     .assertFailsWith[StartupException]
+     .flatMap(e => assertEqual("code", e.code, "28P01"))
+  }
+
+  test("password - successful login") {
+    Session.single[IO](
+      host     = "localhost",
+      user     = "jimmy",
+      database = "world",
+      password = Some("banana"),
+      port     = Port.Password
+    ).use(_ => IO.unit)
+  }
+
+  test("password - non-existent database") {
+    Session.single[IO](
+      host     = "localhost",
+      user     = "jimmy",
+      database = "blah",
+      password = Some("banana"),
+      port     = Port.Password,
+    ).use(_ => IO.unit)
+     .assertFailsWith[StartupException]
+     .flatMap(e => assertEqual("code", e.code, "3D000"))
+  }
+
+  test("password - missing password") {
+    Session.single[IO](
+      host     = "localhost",
+      user     = "jimmy",
+      database = "blah",
+      password = None,
+      port     = Port.Password,
+    ).use(_ => IO.unit)
+     .assertFailsWith[SkunkException]
+     .flatMap(e => assertEqual("message", e.message, "Password required."))
+  }
+
+  test("password - incorrect user") {
+    Session.single[IO](
+      host     = "localhost",
+      user     = "frank",
+      database = "world",
+      password = Some("banana"),
+      port     = Port.Password,
+    ).use(_ => IO.unit)
+     .assertFailsWith[StartupException]
+     .flatMap(e => assertEqual("code", e.code, "28P01"))
+  }
+
+  test("password - incorrect password") {
+    Session.single[IO](
+      host     = "localhost",
+      user     = "jimmy",
+      database = "world",
+      password = Some("apple"),
+      port     = Port.Password,
     ).use(_ => IO.unit)
      .assertFailsWith[StartupException]
      .flatMap(e => assertEqual("code", e.code, "28P01"))

--- a/modules/tests/shared/src/test/scala/simulation/StartupSimTest.scala
+++ b/modules/tests/shared/src/test/scala/simulation/StartupSimTest.scala
@@ -22,7 +22,6 @@ class StartupSimTest extends SimTest {
   }
 
   List(
-    AuthenticationCleartextPassword,
     AuthenticationGSS,
     AuthenticationKerberosV5,
     AuthenticationSCMCredential,


### PR DESCRIPTION
Hit this in a real project.

NB: I’ve done my best to compare this to the docs and [PgJDBC](https://github.com/pgjdbc/pgjdbc/blob/06cecbb00f4babb455303d0330e995095f70d59d/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java#L675-L695), but I must admit I have not tested this (yet) beyond the fact that it compiles. Ideally this would have a test right within the Skunk repo, but I’m not sure how to do it.