### PR TITLE
bit/varbit

### DIFF
--- a/modules/core/shared/src/main/scala/codec/BinaryCodecs.scala
+++ b/modules/core/shared/src/main/scala/codec/BinaryCodecs.scala
@@ -8,6 +8,7 @@ package codec
 import cats.syntax.all._
 import scodec.bits.ByteVector
 import skunk.data.Type
+import scodec.bits.BitVector
 
 trait BinaryCodecs {
 
@@ -15,6 +16,31 @@ trait BinaryCodecs {
     "\\x" + ByteVector.view(_).toHex,
     z => ByteVector.fromHex(z.substring(2)).map(_.toArray).fold("Cannot decode bytes from HEX String".asLeft[Array[Byte]])(_.asRight[String]),
     Type.bytea)
+
+  val bit: Codec[BitVector] =
+    bit(1)
+
+  def bit(length: Int): Codec[BitVector] =
+    Codec.simple[BitVector](
+      _.toBin,
+      s => { println(s"got $s"); BitVector.fromBinDescriptive(s) },
+      // BitVector.fromBinDescriptive(_),
+      Type.bit(length)
+    )
+
+  val varbit: Codec[BitVector] =
+    Codec.simple[BitVector](
+      _.toBin,
+      BitVector.fromBinDescriptive(_),
+      Type.varbit
+    )
+
+  def varbit(length: Int): Codec[BitVector] =
+    Codec.simple[BitVector](
+      _.toBin,
+      BitVector.fromBinDescriptive(_),
+      Type.varbit(length)
+    )
 
 }
 

--- a/modules/core/shared/src/main/scala/data/Type.scala
+++ b/modules/core/shared/src/main/scala/data/Type.scala
@@ -55,6 +55,8 @@ object Type {
   def timestamp(n: Int)       = Type(s"timestamp($n)")
   def timestamptz(n: Int)     = Type(s"timestamptz($n)")
   def interval(n: Int)        = Type(s"interval($n)")
+  def bit(n: Int)             = Type(s"bit($n)")
+  def varbit(n: Int)          = Type(s"varbit($n)")
 
   // Built-in Base Types
   val abstime          = Type("abstime")

--- a/modules/core/shared/src/main/scala/util/Typer.scala
+++ b/modules/core/shared/src/main/scala/util/Typer.scala
@@ -163,8 +163,8 @@ object Typer {
         case Oid.timestamp   => if (typeMod == -1) Some(Type("timestamp"))   else Some(Type(s"timestamp($typeMod)"))
         case Oid.timestamptz => if (typeMod == -1) Some(Type("timestamptz")) else Some(Type(s"timestamptz($typeMod)"))
         case Oid.varchar     => if (typeMod == -1) Some(Type("varchar"))     else Some(Type(s"varchar(${typeMod - 4})"))
-
-        // // varbit
+        case Oid.varbit      => if (typeMod == -1) Some(Type("varbit"))      else Some(Type(s"varbit(${typeMod})"))
+        case Oid.bit         => if (typeMod == -1) Some(Type("bit"))         else Some(Type(s"bit(${typeMod})"))
 
         // Ok we need to handle arrays of those types as well
         case n => staticByOid.get(n)

--- a/modules/docs/src/main/paradox/reference/SchemaTypes.md
+++ b/modules/docs/src/main/paradox/reference/SchemaTypes.md
@@ -65,15 +65,21 @@ Skunk codecs have the same names as their corresponding Postgres data types. Def
 - This codec is importable from `skunk.codec.boolean._` or `skunk.codec.all._`.
 - See [§8.6](https://www.postgresql.org/docs/9.1/datatype-boolean.html) in the Postgres documentation for more information on the boolean data type.
 
-## Binary Type
+## Binary Types
 
-| ANSI SQL Type      | Size                                         | Postgres Type   | Scala Type     |
-|--------------------|----------------------------------------------|-----------------|----------------|
-| `blob`             | 1 or 4 bytes plus the actual binary string   | `bytea`         | `Array[Byte]`  |
+| ANSI SQL Type      | Postgres Type   | Scala Type              | Notes                   |
+|--------------------|-----------------|-------------------------|-------------------------|
+| `blob`             | `bytea`         | `Array[Byte]`           |                         |
+| n/a                | `bit`           | `scodec.bits.BitVector` | Equivalent to `bit(1)`. |
+| n/a                | `bit(n)`        | `scodec.bits.BitVector` | Exactly `n` bits.       |
+| n/a                | `varbit(n)`     | `scodec.bits.BitVector` | At most `n` bits.       |
+| n/a                | `varbit`        | `scodec.bits.BitVector` | Any size.               |
 
 #### Notes
-- This codec uses [Hex Format](https://www.postgresql.org/docs/11/datatype-binary.html#id-1.5.7.12.9). Bytea octets in PostgreSQL are output in hex format by default.
-- See [§8.4](https://www.postgresql.org/docs/11/datatype-binary.html) in the Postgres documentation for more information on binary data types.
+- Prefer `boolean` over `bit`/`bit(1)`.
+- The `bytea` codec uses [Hex Format](https://www.postgresql.org/docs/11/datatype-binary.html#id-1.5.7.12.9). Bytea octets in PostgreSQL are output in hex format by default.
+- See [§8.4](https://www.postgresql.org/docs/11/datatype-binary.html) in the Postgres documentation for more information on the `bytea` data type.
+- See [§8.10](https://www.postgresql.org/docs/11/datatype-bit.html) in the Postgres documentation for more information on the `bit` and `varbit` data types.
 
 ## Enumerated Types
 

--- a/modules/tests/shared/src/test/scala/codec/BinaryCodecTest.scala
+++ b/modules/tests/shared/src/test/scala/codec/BinaryCodecTest.scala
@@ -7,16 +7,44 @@ package codec
 
 import cats.kernel.Eq
 import skunk.codec.all._
+import scodec.bits.BitVector
+import scodec.interop.cats._
 
 class BinaryCodecTest extends CodecTest {
 
   implicit def arrayEq[A]: Eq[Array[A]] = Eq.instance(_.toList == _.toList)
 
+  // bytea
   val byteArray1: Array[Byte] = "someValue".getBytes("UTF-8")
   val byteArray2: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
 
   roundtripTest(bytea)(byteArray1, byteArray2)
   decodeFailureTest(bytea, List("foobar"))
+
+  // Make a bitvector
+  def bv(s: String) = BitVector.fromBin(s).get
+
+  // bit, same as bit(1)
+  roundtripTest(bit)(bv("0"))
+  roundtripTest(bit)(bv("1"))
+  decodeFailureTest(bit, List("foobar"))
+
+  // bit(3)
+  roundtripTest(bit(3))(bv("101"))
+  roundtripWithSpecialValueTest("padding", bit(3), Some("bit(3)"))(bv("1"), _ === bv("100"))
+  roundtripWithSpecialValueTest("truncation", bit(3), Some("bit(3)"))(bv("1011"), _ === bv("101"))
+
+  // varbit
+  roundtripTest(varbit)(bv(""))
+  roundtripTest(varbit)(bv("0"))
+  roundtripTest(varbit)(bv("1001001011011"))
+  decodeFailureTest(varbit, List("foobar"))
+
+  // varbit(3)
+  roundtripTest(varbit(3))(bv(""))
+  roundtripTest(varbit(3))(bv("011"))
+  roundtripWithSpecialValueTest("truncation", varbit(3), Some("varbit(3)"))(bv("1001001011011"), _ === bv("100"))
+  decodeFailureTest(varbit(3), List("foobar"))
 
 }
 


### PR DESCRIPTION
This adds codecs for `bit` and `varbit`, which map to `BitVector`.