### PR TITLE
Added CreateDatabase and DropDatabase completions

### DIFF
--- a/modules/core/shared/src/main/scala/data/Completion.scala
+++ b/modules/core/shared/src/main/scala/data/Completion.scala
@@ -42,6 +42,8 @@ object Completion {
   case object CreateSequence     extends Completion
   case object AlterSequence      extends Completion
   case object DropSequence       extends Completion
+  case object CreateDatabase     extends Completion
+  case object DropDatabase       extends Completion
   // more ...
 
   /**

--- a/modules/core/shared/src/main/scala/net/message/CommandComplete.scala
+++ b/modules/core/shared/src/main/scala/net/message/CommandComplete.scala
@@ -75,6 +75,8 @@ object CommandComplete {
     case "CREATE SEQUENCE"  => apply(Completion.CreateSequence)
     case "ALTER SEQUENCE"   => apply(Completion.AlterSequence)
     case "DROP SEQUENCE"    => apply(Completion.DropSequence)
+    case "CREATE DATABASE"  => apply(Completion.CreateDatabase)
+    case "DROP DATABASE"    => apply(Completion.DropDatabase)
     case Patterns.Select(s) => apply(Completion.Select(s.toInt))
     case Patterns.Delete(s) => apply(Completion.Delete(s.toInt))
     case Patterns.Update(s) => apply(Completion.Update(s.toInt))

--- a/modules/tests/shared/src/test/scala/CommandTest.scala
+++ b/modules/tests/shared/src/test/scala/CommandTest.scala
@@ -153,8 +153,15 @@ class CommandTest extends SkunkTest {
         DROP SEQUENCE IF EXISTS counter_seq
        """.command
 
+  val createDatabase: Command[Void] =
+    sql"""
+        CREATE DATABASE skunk_database
+       """.command
 
-
+  val dropDatabase: Command[Void] =
+    sql"""
+        DROP DATABASE IF EXISTS skunk_database
+       """.command
 
   sessionTest("create table, create index, drop index, alter table and drop table") { s =>
     for {
@@ -215,6 +222,14 @@ class CommandTest extends SkunkTest {
     } yield "ok"
   }
 
+  sessionTest("create database, drop database"){ s=>
+    for{
+      c <- s.execute(createDatabase)
+      _ <- assert("completion", c == Completion.CreateDatabase)
+      c <- s.execute(dropDatabase)
+      _ <- assert("completion", c == Completion.DropDatabase)
+    } yield "ok"
+  }
 
   sessionTest("do command"){ s=>
     for{


### PR DESCRIPTION
Two new `Completion` were added to fix the following messages:

```
skunk.exception.SkunkException:
🔥
🔥  SkunkException
🔥
🔥    Problem: Just constructed an unknown completion 'DROP DATABASE'.  Note that
🔥             your program has not crashed. This message is here to annoy you.
🔥       Hint: Please open an issue, or open a PR adding a case in Completion.scala
🔥             and a parser in CommandComplete.scala
🔥
```

```
skunk.exception.SkunkException:
🔥
🔥  SkunkException
🔥
🔥    Problem: Just constructed an unknown completion 'CREATE DATABASE'.  Note that
🔥             your program has not crashed. This message is here to annoy you.
🔥       Hint: Please open an issue, or open a PR adding a case in Completion.scala
🔥             and a parser in CommandComplete.scala
🔥
```