### PR TITLE
Host and port validation for BitVectorSocket

### DIFF
--- a/modules/tests/shared/src/test/scala/BitVectorSocketTest.scala
+++ b/modules/tests/shared/src/test/scala/BitVectorSocketTest.scala
@@ -7,6 +7,7 @@ package tests
 import cats.effect._
 import com.comcast.ip4s.{Host, IpAddress, Port, SocketAddress}
 import fs2.io.net.{Socket, SocketGroup, SocketOption}
+import skunk.exception.SkunkException
 import skunk.net.BitVectorSocket
 
 class BitVectorSocketTest extends ffstest.FTest {
@@ -20,16 +21,12 @@ class BitVectorSocketTest extends ffstest.FTest {
   }
 
   test("Invalid host") {
-    BitVectorSocket("", 1, dummySg, None).use(_ => IO.unit).assertFailsWith[Exception]
-      .flatMap(e => assertEqual("message", e.getMessage, """Hostname: "" is invalid."""))
+    BitVectorSocket("", 1, dummySg, None).use(_ => IO.unit).assertFailsWith[SkunkException]
+      .flatMap(e => assertEqual("message", e.message, """Hostname: "" is not syntactically valid."""))
   }
   test("Invalid port") {
-    BitVectorSocket("localhost", -1, dummySg, None).use(_ => IO.unit).assertFailsWith[Exception]
-      .flatMap(e => assertEqual("message", e.getMessage, "Port: -1 is invalid."))
-  }
-  test("Invalid host and port") {
-    BitVectorSocket("", -1, dummySg, None).use(_ => IO.unit).assertFailsWith[Exception]
-      .flatMap(e => assertEqual("message", e.getMessage, """Hostname: "" and port: -1 are invalid."""))
+    BitVectorSocket("localhost", -1, dummySg, None).use(_ => IO.unit).assertFailsWith[SkunkException]
+      .flatMap(e => assertEqual("message", e.message, "Port: -1 falls out of the allowed range."))
   }
 
 }

--- a/modules/tests/shared/src/test/scala/BitVectorSocketTest.scala
+++ b/modules/tests/shared/src/test/scala/BitVectorSocketTest.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2018-2021 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package tests
+
+import cats.effect._
+import com.comcast.ip4s.{Host, IpAddress, Port, SocketAddress}
+import fs2.io.net.{Socket, SocketGroup, SocketOption}
+import skunk.net.BitVectorSocket
+
+class BitVectorSocketTest extends ffstest.FTest {
+
+  private val dummySg = new SocketGroup[IO] {
+    override def client(to: SocketAddress[Host], options: List[SocketOption]): Resource[IO, Socket[IO]] = ???
+
+    override def server(address: Option[Host], port: Option[Port], options: List[SocketOption]): fs2.Stream[IO, Socket[IO]] = ???
+
+    override def serverResource(address: Option[Host], port: Option[Port], options: List[SocketOption]): Resource[IO, (SocketAddress[IpAddress], fs2.Stream[IO, Socket[IO]])] = ???
+  }
+
+  test("Invalid host") {
+    BitVectorSocket("", 1, dummySg, None).use(_ => IO.unit).assertFailsWith[Exception]
+      .flatMap(e => assertEqual("message", e.getMessage, """Hostname: "" is invalid."""))
+  }
+  test("Invalid port") {
+    BitVectorSocket("localhost", -1, dummySg, None).use(_ => IO.unit).assertFailsWith[Exception]
+      .flatMap(e => assertEqual("message", e.getMessage, "Port: -1 is invalid."))
+  }
+  test("Invalid host and port") {
+    BitVectorSocket("", -1, dummySg, None).use(_ => IO.unit).assertFailsWith[Exception]
+      .flatMap(e => assertEqual("message", e.getMessage, """Hostname: "" and port: -1 are invalid."""))
+  }
+
+}


### PR DESCRIPTION
Fixes #616 

@tpolecat Do we want to create a class under the `skunk.exception` or are we happy to use the Exception itself? 