### PR TITLE
sync after unroll

### DIFF
--- a/modules/core/shared/src/main/scala/net/protocol/Unroll.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Unroll.scala
@@ -68,13 +68,16 @@ private[protocol] class Unroll[F[_]: MessageSocket: Trace](
         ).raiseError[F, List[List[Option[String]]] ~ Boolean]
       }
 
+    def sync: F[Unit] =
+      (send(Sync) >> expect { case ReadyForQuery(_) => }).whenA(extended)
+
     // N.B. we process all waiting messages to ensure the protocol isn't messed up by decoding
     // failures later on.
     def accumulate(accum: List[List[Option[String]]]): F[List[List[Option[String]]] ~ Boolean] =
       flatExpect {
         case rd @ RowData(_)          => accumulate(rd.fields :: accum)
-        case      CommandComplete(_)  => (accum.reverse ~ false).pure[F]
-        case      PortalSuspended     => (accum.reverse ~ true).pure[F]
+        case      CommandComplete(_)  => sync.as((accum.reverse ~ false))
+        case      PortalSuspended     => sync.as((accum.reverse ~ true))
         case      ErrorResponse(info) => syncAndFail(info)
       }
 


### PR DESCRIPTION
Per the doc:

> At completion of each series of extended-query messages, the frontend should issue a Sync message. This parameterless message causes the backend to close the current transaction if it's not inside a BEGIN/COMMIT transaction block ("close" meaning to commit if no error, or roll back if error). Then a ReadyForQuery response is issued. 

Not doing this can lead to weird behavior if you try to do things on the session after executing a portal (async notifications are stopped, for example).