### PR TITLE
add read timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,20 @@ version: '3'
 services:
   # main instance for testing
   postgres:
-    image: postgres:11
+    # image: postgres:11
+    build:
+      context: world
     command: -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key
-    volumes:
-      - ./world/world.sql:/docker-entrypoint-initdb.d/world.sql
-      - ./world/server.crt:/var/lib/postgresql/server.crt
-      - ./world/server.key:/var/lib/postgresql/server.key
+    # volumes:
+    #   - ./world/world.sql:/docker-entrypoint-initdb.d/world.sql
+    #   - ./world/server.crt:/var/lib/postgresql/server.crt:ro
+    #   - ./world/server.key:/var/lib/postgresql/server.key:ro
     ports:
       - 5432:5432
-    environment:
-      POSTGRES_USER: jimmy
-      POSTGRES_PASSWORD: banana
-      POSTGRES_DB: world
+    # environment:
+    #   POSTGRES_USER: jimmy
+    #   POSTGRES_PASSWORD: banana
+    #   POSTGRES_DB: world
   # for testing password-free login
   trust:
     image: postgres:11

--- a/modules/core/shared/src/main/scala/Session.scala
+++ b/modules/core/shared/src/main/scala/Session.scala
@@ -311,6 +311,7 @@ object Session {
     parameters:   Map[String, String] = Session.DefaultConnectionParameters,
     commandCache: Int = 1024,
     queryCache:   Int = 1024,
+    readTimeout:  Duration = Duration.Inf,
   ): Resource[F, Session[F]] =
     pooled(
       host         = host,
@@ -325,6 +326,7 @@ object Session {
       parameters   = parameters,
       commandCache = commandCache,
       queryCache   = queryCache,
+      readTimeout  = readTimeout
     ).flatten
 
   def fromSocketGroup[F[_]: Temporal: Trace: Console](

--- a/modules/core/shared/src/main/scala/net/BufferedMessageSocket.scala
+++ b/modules/core/shared/src/main/scala/net/BufferedMessageSocket.scala
@@ -14,6 +14,7 @@ import fs2.Stream
 import skunk.data._
 import skunk.net.message._
 import fs2.io.net.{SocketGroup, SocketOption}
+import scala.concurrent.duration.Duration
 
 /**
  * A `MessageSocket` that buffers incoming messages, removing and handling asynchronous back-end
@@ -74,7 +75,7 @@ trait BufferedMessageSocket[F[_]] extends MessageSocket[F] {
 
 object BufferedMessageSocket {
 
-  def apply[F[_]: Concurrent: Console](
+  def apply[F[_]: Temporal: Console](
     host:         String,
     port:         Int,
     queueSize:    Int,
@@ -82,9 +83,10 @@ object BufferedMessageSocket {
     sg:           SocketGroup[F],
     socketOptions: List[SocketOption],
     sslOptions:   Option[SSLNegotiation.Options[F]],
+    readTimeout:  Duration
   ): Resource[F, BufferedMessageSocket[F]] =
     for {
-      ms  <- MessageSocket(host, port, debug, sg, socketOptions, sslOptions)
+      ms  <- MessageSocket(host, port, debug, sg, socketOptions, sslOptions, readTimeout)
       ams <- Resource.make(BufferedMessageSocket.fromMessageSocket[F](ms, queueSize))(_.terminate)
     } yield ams
 

--- a/modules/core/shared/src/main/scala/net/MessageSocket.scala
+++ b/modules/core/shared/src/main/scala/net/MessageSocket.scala
@@ -15,6 +15,7 @@ import scodec.interop.cats._
 import skunk.net.message.{ Sync => _, _ }
 import skunk.util.Origin
 import fs2.io.net.{ SocketGroup, SocketOption }
+import scala.concurrent.duration.Duration
 
 /** A higher-level `BitVectorSocket` that speaks in terms of `Message`. */
 trait MessageSocket[F[_]] {
@@ -86,16 +87,17 @@ object MessageSocket {
       }
     }
 
-  def apply[F[_]: Concurrent: Console](
+  def apply[F[_]: Console: Temporal](
     host:         String,
     port:         Int,
     debug:        Boolean,
     sg:           SocketGroup[F],
     socketOptions: List[SocketOption],
     sslOptions:   Option[SSLNegotiation.Options[F]],
+    readTimeout:  Duration
   ): Resource[F, MessageSocket[F]] =
     for {
-      bvs <- BitVectorSocket(host, port, sg, socketOptions, sslOptions)
+      bvs <- BitVectorSocket(host, port, sg, socketOptions, sslOptions, readTimeout)
       ms  <- Resource.eval(fromBitVectorSocket(bvs, debug))
     } yield ms
 

--- a/modules/tests/shared/src/test/scala-2/codec/TemporalCodecTest.scala
+++ b/modules/tests/shared/src/test/scala-2/codec/TemporalCodecTest.scala
@@ -12,6 +12,7 @@ import java.time._
 import skunk.codec.temporal._
 import cats.effect.{IO, Resource}
 import skunk._, skunk.implicits._
+import scala.concurrent.duration.{ Duration => SDuration }
 
 class TemporalCodecTest extends CodecTest {
 
@@ -23,8 +24,8 @@ class TemporalCodecTest extends CodecTest {
 
   // Also, run these tests with the session set to a timezone other than UTC. Our test instance is
   // set to UTC, which masks the error reported at https://github.com/tpolecat/skunk/issues/313.
-  override def session: Resource[IO,Session[IO]] =
-    super.session.evalTap(s => s.execute(sql"SET TIME ZONE +3".command))
+  override def session(readTimeout: SDuration): Resource[IO,Session[IO]] =
+    super.session(readTimeout).evalTap(s => s.execute(sql"SET TIME ZONE +3".command))
 
   // Date
   val dates: List[LocalDate] =

--- a/modules/tests/shared/src/test/scala/BitVectorSocketTest.scala
+++ b/modules/tests/shared/src/test/scala/BitVectorSocketTest.scala
@@ -9,6 +9,7 @@ import com.comcast.ip4s.{Host, IpAddress, Port, SocketAddress}
 import fs2.io.net.{Socket, SocketGroup, SocketOption}
 import skunk.exception.SkunkException
 import skunk.net.BitVectorSocket
+import scala.concurrent.duration.Duration
 
 class BitVectorSocketTest extends ffstest.FTest {
 
@@ -23,11 +24,11 @@ class BitVectorSocketTest extends ffstest.FTest {
   private val socketOptions = List(SocketOption.noDelay(true))
 
   test("Invalid host") {
-    BitVectorSocket("", 1, dummySg, socketOptions, None).use(_ => IO.unit).assertFailsWith[SkunkException]
+    BitVectorSocket("", 1, dummySg, socketOptions, None, Duration.Inf).use(_ => IO.unit).assertFailsWith[SkunkException]
       .flatMap(e => assertEqual("message", e.message, """Hostname: "" is not syntactically valid."""))
   }
   test("Invalid port") {
-    BitVectorSocket("localhost", -1, dummySg, socketOptions, None).use(_ => IO.unit).assertFailsWith[SkunkException]
+    BitVectorSocket("localhost", -1, dummySg, socketOptions, None, Duration.Inf).use(_ => IO.unit).assertFailsWith[SkunkException]
       .flatMap(e => assertEqual("message", e.message, "Port: -1 falls out of the allowed range."))
   }
 

--- a/modules/tests/shared/src/test/scala/QueryTest.scala
+++ b/modules/tests/shared/src/test/scala/QueryTest.scala
@@ -8,6 +8,9 @@ import skunk.codec.all._
 import skunk.implicits._
 import tests.SkunkTest
 import cats.Eq
+import scala.concurrent.duration._
+import skunk.Decoder
+import skunk.data.Type
 
 class QueryTest extends SkunkTest{
 
@@ -54,5 +57,36 @@ class QueryTest extends SkunkTest{
         }
     }
 
+    val void: Decoder[skunk.Void] = new Decoder[skunk.Void] {
+      def types: List[Type] = List(Type.void)
+      def decode(offset: Int, ss: List[Option[String]]): Either[Decoder.Error, skunk.Void] = Right(skunk.Void)
+    }
+
+
+    pooledTest("timeout", 2.seconds) { getS =>
+        val f = sql"select pg_sleep($int4)"
+        def getErr[X]: Either[Throwable, X] => Option[String] = _.swap.toOption.collect {
+            case e: java.util.concurrent.TimeoutException => e.getMessage()
+        }
+        for {
+            sessionBroken <- getS.use { s =>
+                s.prepare(f.query(void)).use { ps =>
+                    for {
+                        ret <- ps.unique(8).attempt
+                        _ <- assertEqual("timeout error check", getErr(ret), Option("2 seconds"))
+                    } yield "ok"
+                }
+            }.attempt
+            _ <- assertEqual("timeout error check", getErr(sessionBroken), Option("2 seconds"))
+            _ <- getS.use { s =>
+                s.prepare(f.query(void)).use { ps =>
+                    for {
+                        ret <- ps.unique(1).attempt
+                        _ <- assertEqual("timeout error ok", ret.isRight, true)
+                    } yield "ok"
+                }
+            }
+        } yield "ok"
+    }
 
 }

--- a/world/Dockerfile
+++ b/world/Dockerfile
@@ -1,5 +1,11 @@
 FROM postgres:11
+
 ENV POSTGRES_DB world
 ENV POSTGRES_USER jimmy
 ENV POSTGRES_PASSWORD banana
+
 ADD world.sql /docker-entrypoint-initdb.d/
+ADD server.crt /var/lib/postgresql/
+ADD server.key /var/lib/postgresql/
+RUN chown postgres /var/lib/postgresql/server.key && chmod 600 /var/lib/postgresql/server.key
+


### PR DESCRIPTION
Adds read timeout for socket reads.

A reason to add it within the library rather than timing out skunk calls - it also applies for the healthcheck queries.