### PR TITLE
Query dynamic rows

### DIFF
--- a/modules/core/shared/src/main/scala/Fragment.scala
+++ b/modules/core/shared/src/main/scala/Fragment.scala
@@ -28,13 +28,13 @@ final case class Fragment[A](
     } .runA(1).value.combineAll
 
   def query[B](decoder: Decoder[B]): Query[A, B] =
-    Query(sql, origin, encoder, decoder)
+    Query(sql, origin, encoder, decoder, isDynamic = false)
 
   def queryDynamic: Query[A, List[Option[String]]] =
     Query(sql, origin, encoder, new Decoder[List[Option[String]]]{
         def decode(offset: Int, ss: List[Option[String]]): Either[skunk.Decoder.Error,List[Option[String]]] = Right(ss)
         def types: List[skunk.data.Type] = Nil
-    })
+    }, isDynamic = true)
 
   def command: Command[A] =
     Command(sql, origin, encoder)

--- a/modules/core/shared/src/main/scala/Fragment.scala
+++ b/modules/core/shared/src/main/scala/Fragment.scala
@@ -30,6 +30,12 @@ final case class Fragment[A](
   def query[B](decoder: Decoder[B]): Query[A, B] =
     Query(sql, origin, encoder, decoder)
 
+  def queryDynamic: Query[A, List[Option[String]]] =
+    Query(sql, origin, encoder, new Decoder[List[Option[String]]]{
+        def decode(offset: Int, ss: List[Option[String]]): Either[skunk.Decoder.Error,List[Option[String]]] = Right(ss)
+        def types: List[skunk.data.Type] = Nil
+    })
+
   def command: Command[A] =
     Command(sql, origin, encoder)
 

--- a/modules/core/shared/src/main/scala/Query.scala
+++ b/modules/core/shared/src/main/scala/Query.scala
@@ -38,7 +38,8 @@ final case class Query[A, B](
   override val sql:     String,
   override val origin:  Origin,
   override val encoder: Encoder[A],
-  decoder: Decoder[B]
+  decoder: Decoder[B],
+  isDynamic: Boolean = false
 ) extends Statement[A] {
 
   /**
@@ -46,7 +47,7 @@ final case class Query[A, B](
    * @group Transformations
    */
   def dimap[C, D](f: C => A)(g: B => D): Query[C, D] =
-    Query(sql, origin, encoder.contramap(f), decoder.map(g))
+    Query(sql, origin, encoder.contramap(f), decoder.map(g), isDynamic)
 
   /**
    * Query is a contravariant functor in `A`.

--- a/modules/core/shared/src/main/scala/net/protocol/Describe.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Describe.scala
@@ -73,7 +73,7 @@ object Describe {
                       case Right(td) =>
                         Trace[F].put("column-types" -> td.fields.map(_.tpe).mkString("[", ", ", "]")).as(td)
                     }
-              _  <- ColumnAlignmentException(query, td).raiseError[F, Unit].unlessA(query.decoder.types === td.types)
+              _  <- ColumnAlignmentException(query, td).raiseError[F, Unit].unlessA(query.isDynamic || query.decoder.types === td.types)
               _  <- cache.queryCache.put(query, td) // on success
             } yield td
           }

--- a/modules/core/shared/src/main/scala/net/protocol/Query.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Query.scala
@@ -85,7 +85,7 @@ object Query {
               rd.typed(ty) match {
 
                 case Right(td) =>
-                  if (query.decoder.types === td.types) {
+                  if (query.isDynamic || query.decoder.types === td.types) {
                     unroll(
                       extended       = false,
                       sql            = query.sql,


### PR DESCRIPTION
I tried to implement a `.queryDynamic` on `Fragment` with the idea to give me a `Query[A, List[Option[String]]]` for queries, where the schema is not known at compile time. But at runtime, I get an error that the returned rows from postgres don't match the expected types. Any idea?

```
...
a     int4    ->    ── unmapped column
b     bool    ->    ── unmapped column
c     float8  ->    ── unmapped column
...
```

fixes #662 