### PR TITLE
Use `Resource` for `TLSContext`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 )
 
 // This is used in a couple places
-lazy val fs2Version = "3.2.14"
+lazy val fs2Version = "3.3.0"
 lazy val natchezVersion = "0.1.6"
 
 // Global Settings

--- a/modules/core/jvm/src/main/scala/SSLPlatform.scala
+++ b/modules/core/jvm/src/main/scala/SSLPlatform.scala
@@ -5,7 +5,7 @@
 package skunk
 
 import cats._
-import cats.syntax.all._
+import cats.effect.Resource
 import java.nio.file.Path
 import java.security.KeyStore
 import javax.net.ssl.SSLContext
@@ -17,8 +17,8 @@ private[skunk] trait SSLCompanionPlatform { this: SSL.type =>
   /** Creates a `SSL` from an `SSLContext`. */
   def fromSSLContext(ctx: SSLContext): SSL =
     new SSL {
-      def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): F[TLSContext[F]] =
-        Network[F].tlsContext.fromSSLContext(ctx).pure[F]
+      def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
+        Resource.pure(Network[F].tlsContext.fromSSLContext(ctx))
     }
 
   /** Creates a `SSL` from the specified key store file. */
@@ -28,8 +28,8 @@ private[skunk] trait SSLCompanionPlatform { this: SSL.type =>
     keyPassword:   Array[Char],
   ): SSL =
     new SSL {
-      def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): F[TLSContext[F]] =
-       Network[F].tlsContext.fromKeyStoreFile(file, storePassword, keyPassword)
+      def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
+       Resource.eval(Network[F].tlsContext.fromKeyStoreFile(file, storePassword, keyPassword))
     }
 
   /** Creates a `SSL` from the specified class path resource. */
@@ -39,8 +39,8 @@ private[skunk] trait SSLCompanionPlatform { this: SSL.type =>
       keyPassword: Array[Char],
   ): SSL =
     new SSL {
-      def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): F[TLSContext[F]] =
-       Network[F].tlsContext.fromKeyStoreResource(resource, storePassword, keyPassword)
+      def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
+       Resource.eval(Network[F].tlsContext.fromKeyStoreResource(resource, storePassword, keyPassword))
     }
 
   /** Creates a `TLSContext` from the specified key store. */
@@ -49,8 +49,8 @@ private[skunk] trait SSLCompanionPlatform { this: SSL.type =>
       keyPassword: Array[Char],
   ): SSL =
     new SSL {
-      def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): F[TLSContext[F]] =
-       Network[F].tlsContext.fromKeyStore(keyStore, keyPassword)
+      def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
+       Resource.eval(Network[F].tlsContext.fromKeyStore(keyStore, keyPassword))
     }
 
 }

--- a/modules/core/shared/src/main/scala/SSL.scala
+++ b/modules/core/shared/src/main/scala/SSL.scala
@@ -5,6 +5,7 @@
 package skunk
 
 import cats._
+import cats.effect.Resource
 import cats.syntax.all._
 import fs2.io.net.Network
 import fs2.io.net.tls.TLSContext
@@ -16,25 +17,25 @@ abstract class SSL private[skunk] (
   val fallbackOk:    Boolean       = false,
 ) { outer =>
 
-  def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): F[TLSContext[F]]
+  def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]]
 
   def withTLSParameters(tlsParameters: TLSParameters): SSL =
     new SSL(tlsParameters, fallbackOk) {
-      def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): F[TLSContext[F]] =
+      def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
         outer.tlsContext
     }
 
   def withFallback(fallbackOk: Boolean): SSL =
     new SSL(tlsParameters, fallbackOk) {
-      def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): F[TLSContext[F]] =
+      def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
         outer.tlsContext
     }
 
   def toSSLNegotiationOptions[F[_]: Network](logger: Option[String => F[Unit]])(
     implicit ev: ApplicativeError[F, Throwable]
-  ): F[Option[SSLNegotiation.Options[F]]] =
+  ): Resource[F, Option[SSLNegotiation.Options[F]]] =
     this match {
-      case SSL.None => none.pure[F]
+      case SSL.None => Resource.pure(None)
       case _ => tlsContext.map(SSLNegotiation.Options(_, tlsParameters, fallbackOk, logger).some)
     }
 
@@ -44,22 +45,22 @@ object SSL extends SSLCompanionPlatform {
 
   /** `SSL` which indicates that SSL is not to be used. */
   object None extends SSL {
-    def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): F[TLSContext[F]] =
-      ev.raiseError(new Exception("SSL.None: cannot create a TLSContext."))
+    def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
+      Resource.eval(ev.raiseError(new Exception("SSL.None: cannot create a TLSContext.")))
     override def withFallback(fallbackOk: Boolean): SSL = this
     override def withTLSParameters(tlsParameters: TLSParameters): SSL = this
   }
 
   /** `SSL` which trusts all certificates. */
   object Trusted extends SSL {
-    def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): F[TLSContext[F]] =
-      Network[F].tlsContext.insecure
+    def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
+      Network[F].tlsContext.insecureResource
   }
 
   /** `SSL` from the system default `SSLContext`. */
   object System extends SSL {
-    def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): F[TLSContext[F]] =
-      Network[F].tlsContext.system
+    def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
+      Network[F].tlsContext.systemResource
   }
 
 }

--- a/modules/core/shared/src/main/scala/Session.scala
+++ b/modules/core/shared/src/main/scala/Session.scala
@@ -281,7 +281,7 @@ object Session {
 
     for {
       dc      <- Resource.eval(Describe.Cache.empty[F](commandCache, queryCache))
-      sslOp   <- Resource.eval(ssl.toSSLNegotiationOptions(if (debug) logger.some else none))
+      sslOp   <- ssl.toSSLNegotiationOptions(if (debug) logger.some else none)
       pool    <- Pool.of(session(Network[F], sslOp, dc), max)(Recyclers.full)
     } yield pool
 

--- a/modules/tests/shared/src/test/scala/SslTest.scala
+++ b/modules/tests/shared/src/test/scala/SslTest.scala
@@ -79,7 +79,7 @@ class SslTest extends ffstest.FTest {
 
   test("SSL.None cannot produce an SSLContext") {
     for {
-      ex <- SSL.None.tlsContext[IO].assertFailsWith[Exception]
+      ex <- SSL.None.tlsContext[IO].use_.assertFailsWith[Exception]
       _  <- assertEqual("failure message", ex.getMessage, "SSL.None: cannot create a TLSContext.")
     } yield "ok"
   }


### PR DESCRIPTION
This pulls out the breaking change from the Native PR https://github.com/tpolecat/skunk/pull/703, which may be blocked for a while still on upstream dependencies.

Although this is a fairly breaking change I'm not convinced this is really a user-facing API. Seems like it would be strange to be building `TLSContext`s with Skunk `SSL`.

If we're 👎 on this change, then the Native PR will have to introduce some platforming to work around this, not the end of the world.