### PR TITLE
Configure codecov to only fail if there is at least 1 percent decrease in coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+


### PR DESCRIPTION
With the default codecov.io configuration, lots of good builds are marked failed due to slight variance in branch coverage, likely caused by different generated values.