### PR TITLE
Implement per-session parsed statement cache

### DIFF
--- a/modules/core/shared/src/main/scala/Session.scala
+++ b/modules/core/shared/src/main/scala/Session.scala
@@ -133,7 +133,7 @@ trait Session[F[_]] {
    * times with different arguments.
    * @group Queries
    */
-  def prepare[A, B](query: Query[A, B]): Resource[F, PreparedQuery[F, A, B]] = 
+  def prepare[A, B](query: Query[A, B]): Resource[F, PreparedQuery[F, A, B]] =
     Resource.eval(prepareAndCache(query))
 
   /**
@@ -143,16 +143,16 @@ trait Session[F[_]] {
    */
   def prepare[A](command: Command[A]): Resource[F, PreparedCommand[F, A]] =
     Resource.eval(prepareAndCache(command))
-  
+
   /**
-   * Prepares then cache a query, yielding a `PreparedQuery` which can be executed multiple
-   * times with different arguments. 
+   * Prepares then caches a query, yielding a `PreparedQuery` which can be executed multiple
+   * times with different arguments.
    * @group Queries
    */
   def prepareAndCache[A, B](query: Query[A, B]): F[PreparedQuery[F, A, B]]
 
   /**
-   * Prepares then cache an `INSERT`, `UPDATE`, or `DELETE` command that returns no rows. The resulting
+   * Prepares then caches an `INSERT`, `UPDATE`, or `DELETE` command that returns no rows. The resulting
    * `PreparedCommand` can be executed multiple times with different arguments.
    * @group Commands
    */

--- a/modules/core/shared/src/main/scala/Session.scala
+++ b/modules/core/shared/src/main/scala/Session.scala
@@ -23,6 +23,7 @@ import skunk.data.TransactionIsolationLevel
 import skunk.data.TransactionAccessMode
 import skunk.net.protocol.Describe
 import scala.concurrent.duration.Duration
+import skunk.net.protocol.Parse
 
 /**
  * Represents a live connection to a Postgres database. Operations provided here are safe to use
@@ -277,11 +278,22 @@ object Session {
     socketOptions:   List[SocketOption] = Session.DefaultSocketOptions,
     commandCache: Int = 1024,
     queryCache:   Int = 1024,
+<<<<<<< HEAD
     readTimeout:  Duration = Duration.Inf,
   ): Resource[F, Resource[F, Session[F]]] = {
 
     def session(socketGroup: SocketGroup[F], sslOp: Option[SSLNegotiation.Options[F]], cache: Describe.Cache[F]): Resource[F, Session[F]] =
       fromSocketGroup[F](socketGroup, host, port, user, database, password, debug, strategy, socketOptions, sslOp, parameters, cache, readTimeout)
+=======
+    parseCache:   Int = 1024
+  ): Resource[F, Resource[F, Session[F]]] = {
+
+    def session(socketGroup: SocketGroup[F], sslOp: Option[SSLNegotiation.Options[F]], cache: Describe.Cache[F]): Resource[F, Session[F]] =
+      for {
+        pc <- Resource.eval(Parse.Cache.empty[F](parseCache))
+        s  <- fromSocketGroup[F](socketGroup, host, port, user, database, password, debug, strategy, socketOptions, sslOp, parameters, cache, pc)
+      } yield s
+>>>>>>> Add parse step caching + boilerplate
 
     val logger: String => F[Unit] = s => Console[F].println(s"TLS: $s")
 
@@ -311,7 +323,11 @@ object Session {
     parameters:   Map[String, String] = Session.DefaultConnectionParameters,
     commandCache: Int = 1024,
     queryCache:   Int = 1024,
+<<<<<<< HEAD
     readTimeout:  Duration = Duration.Inf,
+=======
+    parseCache:   Int = 1024
+>>>>>>> Add parse step caching + boilerplate
   ): Resource[F, Session[F]] =
     pooled(
       host         = host,
@@ -326,7 +342,11 @@ object Session {
       parameters   = parameters,
       commandCache = commandCache,
       queryCache   = queryCache,
+<<<<<<< HEAD
       readTimeout  = readTimeout
+=======
+      parseCache   = parseCache
+>>>>>>> Add parse step caching + boilerplate
     ).flatten
 
   def fromSocketGroup[F[_]: Temporal: Trace: Console](
@@ -342,11 +362,19 @@ object Session {
     sslOptions:   Option[SSLNegotiation.Options[F]],
     parameters:   Map[String, String],
     describeCache: Describe.Cache[F],
+<<<<<<< HEAD
     readTimeout:  Duration = Duration.Inf,
   ): Resource[F, Session[F]] =
     for {
       namer <- Resource.eval(Namer[F])
       proto <- Protocol[F](host, port, debug, namer, socketGroup, socketOptions, sslOptions, describeCache, readTimeout)
+=======
+    parseCache: Parse.Cache[F]
+  ): Resource[F, Session[F]] =
+    for {
+      namer <- Resource.eval(Namer[F])
+      proto <- Protocol[F](host, port, debug, namer, socketGroup, socketOptions, sslOptions, describeCache, parseCache)
+>>>>>>> Add parse step caching + boilerplate
       _     <- Resource.eval(proto.startup(user, database, password, parameters))
       sess  <- Resource.eval(fromProtocol(proto, namer, strategy))
     } yield sess

--- a/modules/core/shared/src/main/scala/data/SemispaceCache.scala
+++ b/modules/core/shared/src/main/scala/data/SemispaceCache.scala
@@ -28,9 +28,8 @@ sealed abstract case class SemispaceCache[K, V](gen0: Map[K, V], gen1: Map[K, V]
   def containsKey(k: K): Boolean =
     gen0.contains(k) || gen1.contains(k)
 
-  def values: Seq[V] = 
-    (gen0.values.toSet | gen1.values.toSet).toSeq 
-
+  def values: Seq[V] =
+    (gen0.values.toSet | gen1.values.toSet).toSeq
 }
 
 object SemispaceCache {

--- a/modules/core/shared/src/main/scala/data/SemispaceCache.scala
+++ b/modules/core/shared/src/main/scala/data/SemispaceCache.scala
@@ -28,8 +28,8 @@ sealed abstract case class SemispaceCache[K, V](gen0: Map[K, V], gen1: Map[K, V]
   def containsKey(k: K): Boolean =
     gen0.contains(k) || gen1.contains(k)
 
-  def values: Seq[V] =
-    (gen0.values.toSet | gen1.values.toSet).toSeq
+  def values: List[V] =
+    (gen0.values.toSet | gen1.values.toSet).toList
 }
 
 object SemispaceCache {

--- a/modules/core/shared/src/main/scala/data/SemispaceCache.scala
+++ b/modules/core/shared/src/main/scala/data/SemispaceCache.scala
@@ -28,6 +28,9 @@ sealed abstract case class SemispaceCache[K, V](gen0: Map[K, V], gen1: Map[K, V]
   def containsKey(k: K): Boolean =
     gen0.contains(k) || gen1.contains(k)
 
+  def values: Seq[V] = 
+    (gen0.values.toSet | gen1.values.toSet).toSeq 
+
 }
 
 object SemispaceCache {

--- a/modules/core/shared/src/main/scala/net/Protocol.scala
+++ b/modules/core/shared/src/main/scala/net/Protocol.scala
@@ -63,13 +63,13 @@ trait Protocol[F[_]] {
 
   /**
    * Prepare a command (a statement that produces no rows), yielding a `Protocol.PreparedCommand`
-   * which will cached per session and closed on session close.
+   * which will be cached per session and closed on session close.
    */
   def prepare[A](command: Command[A], ty: Typer): F[Protocol.PreparedCommand[F, A]]
 
   /**
    * Prepare a query (a statement that produces rows), yielding a `Protocol.PreparedCommand` which
-   * which will cached per session and closed on session close.
+   * which will be cached per session and closed on session close.
    */
   def prepare[A, B](query: Query[A, B], ty: Typer): F[Protocol.PreparedQuery[F, A, B]]
 
@@ -94,9 +94,9 @@ trait Protocol[F[_]] {
   def startup(user: String, database: String, password: Option[String], parameters: Map[String, String]): F[Unit]
 
   /**
-   * Cleanup the session. This will close ay cached prepared statement
+   * Cleanup the session. This will close any cached prepared statements.
    */
-  def cleanup:F[Unit]
+  def cleanup: F[Unit]
 
   /**
    * Signal representing the current transaction status as reported by `ReadyForQuery`. It's not
@@ -106,10 +106,9 @@ trait Protocol[F[_]] {
 
   /** Cache for the `Describe` protocol. */
   def describeCache: Describe.Cache[F]
-  
+
   /** Cache for the `Parse` protocol. */
   def parseCache: Parse.Cache[F]
-
 }
 
 object Protocol {

--- a/modules/core/shared/src/main/scala/net/Protocol.scala
+++ b/modules/core/shared/src/main/scala/net/Protocol.scala
@@ -72,6 +72,18 @@ trait Protocol[F[_]] {
    * which will be closed after use.
    */
   def prepare[A, B](query: Query[A, B], ty: Typer): Resource[F, Protocol.PreparedQuery[F, A, B]]
+  
+  /**
+   * Prepare a command (a statement that produces no rows), yielding a `Protocol.PreparedCommand`
+   * which will cached per session and closed on session close.
+   */
+  def prepareAndCache[A](command: Command[A], ty: Typer): F[Protocol.PreparedCommand[F, A]]
+
+  /**
+   * Prepare a query (a statement that produces rows), yielding a `Protocol.PreparedCommand` which
+   * which will cached per session and closed on session close.
+   */
+  def prepareAndCache[A, B](query: Query[A, B], ty: Typer): F[Protocol.PreparedQuery[F, A, B]]
 
   /**
    * Execute a non-parameterized command (a statement that produces no rows), yielding a
@@ -240,6 +252,12 @@ object Protocol {
 
         override def prepare[A, B](query: Query[A, B], ty: Typer): Resource[F, PreparedQuery[F, A, B]] =
           protocol.Prepare[F](describeCache, parseCache).apply(query, ty)
+        
+        override def prepareAndCache[A](command: Command[A], ty: Typer): F[PreparedCommand[F, A]] =
+          protocol.Prepare[F](describeCache, parseCache).prepareAndCache(command, ty)
+
+        override def prepareAndCache[A, B](query: Query[A, B], ty: Typer): F[PreparedQuery[F, A, B]] =
+          protocol.Prepare[F](describeCache, parseCache).prepareAndCache(query, ty)
 
         override def execute(command: Command[Void]): F[Completion] =
           protocol.Query[F].apply(command)

--- a/modules/core/shared/src/main/scala/net/protocol/Parse.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Parse.scala
@@ -6,7 +6,6 @@ package skunk.net.protocol
 
 import cats._
 import cats.effect.Ref
-import cats.effect.Resource
 import cats.syntax.all._
 import skunk.util.StatementCache
 import skunk.exception.PostgresErrorException
@@ -21,9 +20,7 @@ import natchez.Trace
 import cats.data.OptionT
 
 trait Parse[F[_]] {
-  def prepareAndCache[A](statement: Statement[A], ty: Typer): F[StatementId]
-  def apply[A](statement: Statement[A], ty: Typer): Resource[F, StatementId] = 
-    Resource.eval(prepareAndCache(statement, ty))
+  def apply[A](statement: Statement[A], ty: Typer): F[StatementId]
 }
 
 object Parse {
@@ -32,7 +29,7 @@ object Parse {
     implicit ev: MonadError[F, Throwable]
   ): Parse[F] =
     new Parse[F] {
-      override def prepareAndCache[A](statement: Statement[A], ty: Typer): F[StatementId] =
+      override def apply[A](statement: Statement[A], ty: Typer): F[StatementId] =
         statement.encoder.oids(ty) match {
 
           case Right(os) if os.length > Short.MaxValue =>

--- a/modules/core/shared/src/main/scala/net/protocol/Parse.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Parse.scala
@@ -82,7 +82,7 @@ object Parse {
   }
 
   object Cache {
-    def empty[F[_]: Functor: Semigroupal: Ref.Make](capacity: Int): F[Cache[F]] =
+    def empty[F[_]: Functor: Ref.Make](capacity: Int): F[Cache[F]] =
       StatementCache.empty[F, StatementId](capacity).map(Parse.Cache(_))
   }
 

--- a/modules/core/shared/src/main/scala/net/protocol/Parse.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Parse.scala
@@ -38,7 +38,7 @@ object Parse {
             Resource.eval(TooManyParametersException(statement).raiseError[F, StatementId])
 
           case Right(os) =>
-            Resource.make {
+            Resource.eval {
               OptionT(cache.value.get(statement)).getOrElseF {
                 exchange("parse") {
                   for {
@@ -57,7 +57,7 @@ object Parse {
                   } yield id
                 }
               }
-            } { Close[F].apply }
+            }
 
           case Left(err) =>
             Resource.eval(UnknownTypeException(statement, err, ty.strategy).raiseError[F, StatementId])

--- a/modules/core/shared/src/main/scala/net/protocol/Prepare.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Prepare.scala
@@ -6,6 +6,8 @@ package skunk.net.protocol
 
 import cats.effect.Resource
 import cats.MonadError
+import cats.syntax.flatMap._
+import cats.syntax.functor._
 import skunk.~
 import skunk.data.Completion
 import skunk.net.MessageSocket
@@ -17,6 +19,9 @@ import natchez.Trace
 trait Prepare[F[_]] {
   def apply[A](command: skunk.Command[A], ty: Typer): Resource[F, PreparedCommand[F, A]]
   def apply[A, B](query: skunk.Query[A, B], ty: Typer): Resource[F, PreparedQuery[F, A, B]]
+  
+  def prepareAndCache[A](command: skunk.Command[A], ty: Typer): F[PreparedCommand[F, A]]
+  def prepareAndCache[A, B](query: skunk.Query[A, B], ty: Typer): F[PreparedQuery[F, A, B]]
 }
 
 object Prepare {
@@ -44,6 +49,34 @@ object Prepare {
         for {
           id <- Parse[F](parseCache).apply(query, ty)
           rd <- Resource.eval(Describe[F](describeCache).apply(query, id, ty))
+        } yield new PreparedQuery[F, A, B](id, query, rd) { pq =>
+          def bind(args: A, origin: Origin): Resource[F, QueryPortal[F, A, B]] =
+            Bind[F].apply(this, args, origin).map {
+              new QueryPortal[F, A, B](_, pq, args, origin) {
+                def execute(maxRows: Int): F[List[B] ~ Boolean] =
+                  Execute[F].apply(this, maxRows, ty)
+              }
+            }
+        }
+      
+      override def prepareAndCache[A](command: skunk.Command[A], ty: Typer): F[PreparedCommand[F, A]] =
+        for {
+          id <- Parse[F](parseCache).prepareAndCache(command, ty)
+          _  <- Describe[F](describeCache).apply(command, id, ty)
+        } yield new PreparedCommand[F, A](id, command) { pc =>
+          def bind(args: A, origin: Origin): Resource[F, CommandPortal[F, A]] =
+            Bind[F].apply(this, args, origin).map {
+              new CommandPortal[F, A](_, pc, args, origin) {
+                val execute: F[Completion] =
+                  Execute[F].apply(this)
+              }
+            }
+        }
+      
+      override def prepareAndCache[A, B](query: skunk.Query[A, B], ty: Typer): F[PreparedQuery[F, A, B]] =
+        for {
+          id <- Parse[F](parseCache).prepareAndCache(query, ty)
+          rd <- Describe[F](describeCache).apply(query, id, ty)
         } yield new PreparedQuery[F, A, B](id, query, rd) { pq =>
           def bind(args: A, origin: Origin): Resource[F, QueryPortal[F, A, B]] =
             Bind[F].apply(this, args, origin).map {

--- a/modules/core/shared/src/main/scala/net/protocol/Prepare.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Prepare.scala
@@ -17,11 +17,8 @@ import skunk.util.Typer
 import natchez.Trace
 
 trait Prepare[F[_]] {
-  def apply[A](command: skunk.Command[A], ty: Typer): Resource[F, PreparedCommand[F, A]]
-  def apply[A, B](query: skunk.Query[A, B], ty: Typer): Resource[F, PreparedQuery[F, A, B]]
-  
-  def prepareAndCache[A](command: skunk.Command[A], ty: Typer): F[PreparedCommand[F, A]]
-  def prepareAndCache[A, B](query: skunk.Query[A, B], ty: Typer): F[PreparedQuery[F, A, B]]
+  def apply[A](command: skunk.Command[A], ty: Typer): F[PreparedCommand[F, A]]
+  def apply[A, B](query: skunk.Query[A, B], ty: Typer): F[PreparedQuery[F, A, B]]
 }
 
 object Prepare {
@@ -31,37 +28,9 @@ object Prepare {
   ): Prepare[F] =
     new Prepare[F] {
 
-      override def apply[A](command: skunk.Command[A], ty: Typer): Resource[F, PreparedCommand[F, A]] =
+      override def apply[A](command: skunk.Command[A], ty: Typer): F[PreparedCommand[F, A]] =
         for {
           id <- Parse[F](parseCache).apply(command, ty)
-          _  <- Resource.eval(Describe[F](describeCache).apply(command, id, ty))
-        } yield new PreparedCommand[F, A](id, command) { pc =>
-          def bind(args: A, origin: Origin): Resource[F, CommandPortal[F, A]] =
-            Bind[F].apply(this, args, origin).map {
-              new CommandPortal[F, A](_, pc, args, origin) {
-                val execute: F[Completion] =
-                  Execute[F].apply(this)
-              }
-            }
-        }
-
-      override def apply[A, B](query: skunk.Query[A, B], ty: Typer): Resource[F, PreparedQuery[F, A, B]] =
-        for {
-          id <- Parse[F](parseCache).apply(query, ty)
-          rd <- Resource.eval(Describe[F](describeCache).apply(query, id, ty))
-        } yield new PreparedQuery[F, A, B](id, query, rd) { pq =>
-          def bind(args: A, origin: Origin): Resource[F, QueryPortal[F, A, B]] =
-            Bind[F].apply(this, args, origin).map {
-              new QueryPortal[F, A, B](_, pq, args, origin) {
-                def execute(maxRows: Int): F[List[B] ~ Boolean] =
-                  Execute[F].apply(this, maxRows, ty)
-              }
-            }
-        }
-      
-      override def prepareAndCache[A](command: skunk.Command[A], ty: Typer): F[PreparedCommand[F, A]] =
-        for {
-          id <- Parse[F](parseCache).prepareAndCache(command, ty)
           _  <- Describe[F](describeCache).apply(command, id, ty)
         } yield new PreparedCommand[F, A](id, command) { pc =>
           def bind(args: A, origin: Origin): Resource[F, CommandPortal[F, A]] =
@@ -73,9 +42,9 @@ object Prepare {
             }
         }
       
-      override def prepareAndCache[A, B](query: skunk.Query[A, B], ty: Typer): F[PreparedQuery[F, A, B]] =
+      override def apply[A, B](query: skunk.Query[A, B], ty: Typer): F[PreparedQuery[F, A, B]] =
         for {
-          id <- Parse[F](parseCache).prepareAndCache(query, ty)
+          id <- Parse[F](parseCache).apply(query, ty)
           rd <- Describe[F](describeCache).apply(query, id, ty)
         } yield new PreparedQuery[F, A, B](id, query, rd) { pq =>
           def bind(args: A, origin: Origin): Resource[F, QueryPortal[F, A, B]] =

--- a/modules/core/shared/src/main/scala/net/protocol/Prepare.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Prepare.scala
@@ -41,7 +41,7 @@ object Prepare {
               }
             }
         }
-      
+
       override def apply[A, B](query: skunk.Query[A, B], ty: Typer): F[PreparedQuery[F, A, B]] =
         for {
           id <- Parse[F](parseCache).apply(query, ty)

--- a/modules/core/shared/src/main/scala/util/StatementCache.scala
+++ b/modules/core/shared/src/main/scala/util/StatementCache.scala
@@ -17,6 +17,7 @@ sealed trait StatementCache[F[_], V] { outer =>
   private[skunk] def put(k: Statement[_], v: V): F[Unit]
   def containsKey(k: Statement[_]): F[Boolean]
   def clear: F[Unit]
+  def values: F[Seq[V]]
 
   def mapK[G[_]](fk: F ~> G): StatementCache[G, V] =
     new StatementCache[G, V] {
@@ -24,6 +25,7 @@ sealed trait StatementCache[F[_], V] { outer =>
       def put(k: Statement[_], v: V): G[Unit] = fk(outer.put(k, v))
       def containsKey(k: Statement[_]): G[Boolean] = fk(outer.containsKey(k))
       def clear: G[Unit] = fk(outer.clear)
+      def values: G[Seq[V]] = fk(outer.values)
     }
 
 }
@@ -51,6 +53,8 @@ object StatementCache {
         def clear: F[Unit] =
           ref.set(SemispaceCache.empty[Statement.CacheKey, V](max))
 
+        def values: F[Seq[V]] =
+          ref.get.map(_.values)
       }
     }
 

--- a/modules/core/shared/src/main/scala/util/StatementCache.scala
+++ b/modules/core/shared/src/main/scala/util/StatementCache.scala
@@ -17,7 +17,7 @@ sealed trait StatementCache[F[_], V] { outer =>
   private[skunk] def put(k: Statement[_], v: V): F[Unit]
   def containsKey(k: Statement[_]): F[Boolean]
   def clear: F[Unit]
-  def values: F[Seq[V]]
+  def values: F[List[V]]
 
   def mapK[G[_]](fk: F ~> G): StatementCache[G, V] =
     new StatementCache[G, V] {
@@ -25,7 +25,7 @@ sealed trait StatementCache[F[_], V] { outer =>
       def put(k: Statement[_], v: V): G[Unit] = fk(outer.put(k, v))
       def containsKey(k: Statement[_]): G[Boolean] = fk(outer.containsKey(k))
       def clear: G[Unit] = fk(outer.clear)
-      def values: G[Seq[V]] = fk(outer.values)
+      def values: G[List[V]] = fk(outer.values)
     }
 
 }
@@ -53,7 +53,7 @@ object StatementCache {
         def clear: F[Unit] =
           ref.set(SemispaceCache.empty[Statement.CacheKey, V](max))
 
-        def values: F[Seq[V]] =
+        def values: F[List[V]] =
           ref.get.map(_.values)
       }
     }

--- a/modules/tests/shared/src/test/scala/simulation/SimTest.scala
+++ b/modules/tests/shared/src/test/scala/simulation/SimTest.scala
@@ -21,6 +21,7 @@ import skunk.util.Namer
 import skunk.util.Origin
 import skunk.util.Typer
 import skunk.net.protocol.Describe
+import skunk.net.protocol.Parse
 
 trait SimTest extends FTest with SimMessageSocket.DSL {
 
@@ -42,7 +43,8 @@ trait SimTest extends FTest with SimMessageSocket.DSL {
       bms <- SimMessageSocket(sim).map(new SimulatedBufferedMessageSocket(_))
       nam <- Namer[IO]
       dc  <- Describe.Cache.empty[IO](1024, 1024)
-      pro <- Protocol.fromMessageSocket(bms, nam, dc)
+      pc  <- Parse.Cache.empty[IO](1024)
+      pro <- Protocol.fromMessageSocket(bms, nam, dc, pc)
       _   <- pro.startup(user, database, password, Session.DefaultConnectionParameters)
       ses <- Session.fromProtocol(pro, nam, Typer.Strategy.BuiltinsOnly)
     } yield ses


### PR DESCRIPTION
An attempt to solve #496.

The parse statement cache is modeled after the Describe one in term of API / implementation and visibility.
I added handles to get all the data in cache in order to handle the session cleanup.

The cleanup is done at the `Protocol[F]` level.

I finally decided to keep the `Parse.apply` in `Resource` to not break a lot of code, this could be handled as a follow up pr. 

Open to all suggestions :)