### PR TITLE
Fix mdoc markdown processing

### DIFF
--- a/modules/docs/src/main/paradox/tutorial/Command.md
+++ b/modules/docs/src/main/paradox/tutorial/Command.md
@@ -280,7 +280,7 @@ object CommandExample extends IOApp {
 
 Running this program yields the following.
 
-```scala mdoc:passthrough
+```scala mdoc:compile-only
 println("```")
 import skunk.mdoc._
 CommandExample.run(Nil).unsafeRunSyncWithRedirect()

--- a/modules/docs/src/main/paradox/tutorial/Query.md
+++ b/modules/docs/src/main/paradox/tutorial/Query.md
@@ -313,7 +313,7 @@ object QueryExample extends IOApp {
 
 Running this program yields the following.
 
-```scala mdoc:passthrough
+```scala mdoc:compile-only
 println("```")
 import skunk.mdoc._
 QueryExample.run(Nil).unsafeRunSyncWithRedirect()
@@ -404,7 +404,7 @@ object QueryExample2 extends IOApp {
 
 Running this program yields the same output as above.
 
-```scala mdoc:passthrough
+```scala mdoc:compile-only
 println("```")
 import skunk.mdoc._
 QueryExample2.run(Nil).unsafeRunSyncWithRedirect()

--- a/modules/docs/src/main/paradox/tutorial/Setup.md
+++ b/modules/docs/src/main/paradox/tutorial/Setup.md
@@ -70,7 +70,7 @@ Let's examine the code above.
 
 When we run the program we see the current date.
 
-```scala mdoc:passthrough
+```scala mdoc:compile-only
 println("```")
 import skunk.mdoc._
 Hello.run(Nil).unsafeRunSyncWithRedirect()

--- a/modules/docs/src/main/paradox/tutorial/Transactions.md
+++ b/modules/docs/src/main/paradox/tutorial/Transactions.md
@@ -222,7 +222,7 @@ object TransactionExample extends IOApp {
 
 Running this program yields the following.
 
-```scala mdoc:passthrough
+```scala mdoc:compile-only
 println("```")
 import skunk.mdoc._
 TransactionExample.run(Nil).unsafeRunSyncWithRedirect()


### PR DESCRIPTION
# Why 

At the moment, the creation of Skunk's documentation with sbt `docs/makeSite` command fails with a `Connection refused` error, as visible in https://github.com/tpolecat/skunk/issues/713#issuecomment-1258124108

The error occurs during the execution of `docs/mdoc` which tries to open a socket when running snippets like `CommandExample.run(Nil).unsafeRunSyncWithRedirect()` 

# What

This PR fixes the issue by marking those snippet as `compile-only`, telling mdoc not to try to execute them. 

# How to test

Running `docs/makeSite` on this branch no longer triggers the connection error and produces a static web site  in `modules/docs/target/paradox/site/main/`


