### PR TITLE
Change prepare to return F[..] instead of Resource[F, ..], add prepareR with old signature

### DIFF
--- a/modules/docs/src/main/paradox/reference/Fragments.md
+++ b/modules/docs/src/main/paradox/reference/Fragments.md
@@ -171,6 +171,6 @@ To prepare and execute some `af: AppliedFragment` you must extract its underlyin
 def usage(s: Session[IO]) = {
   val f = countryQuery(Some("Un%"), None) // AppliedFragment
   val q = f.fragment.query(varchar)       // Query[f.A, String]
-  s.prepare(q).use(_.stream(f.argument, 64).compile.to(List))
+  s.prepare(q).flatMap(_.stream(f.argument, 64).compile.to(List))
 }
 ```

--- a/modules/docs/src/main/paradox/tutorial/Channels.md
+++ b/modules/docs/src/main/paradox/tutorial/Channels.md
@@ -63,7 +63,7 @@ Every `Channel` is also an fs2 `Pipe` that consumes messages.
 ```scala mdoc:compile-only
 // assume s: Session[IO]
 // select all the country names and stream them to the country_names channel.
-s.prepare(sql"select name from country".query(varchar)).use { ps =>
+s.prepare(sql"select name from country".query(varchar)).flatMap { ps =>
   ps.stream(Void, 512)
     .through(s.channel(id"country_names"))
     .compile

--- a/modules/docs/src/main/paradox/tutorial/Command.md
+++ b/modules/docs/src/main/paradox/tutorial/Command.md
@@ -90,7 +90,7 @@ And if we're yet more clever we can turn `pc` into an fs2 `Pipe`.
 
 ```scala mdoc:compile-only
 // assume s: Session[IO]
-Stream.resource(s.prepare(c)).flatMap { pc =>
+Stream.eval(s.prepare(c)).flatMap { pc =>
   Stream("xyzzy", "fnord", "blech").through(pc.pipe)
 } // Stream[IO, Completion]
 ```
@@ -192,8 +192,9 @@ The *extend command protocol* (i.e., `Session#prepare`) is more powerful and mor
 Here is a complete program listing that demonstrates our knowledge thus far, using the service pattern introduced earlier.
 
 ```scala mdoc:reset
+import cats.Monad
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import natchez.Trace.Implicits.noop
 import skunk._
 import skunk.codec.all._

--- a/modules/docs/src/main/paradox/tutorial/Command.md
+++ b/modules/docs/src/main/paradox/tutorial/Command.md
@@ -70,7 +70,7 @@ Here we use the extended protocol to attempt some deletions.
 
 ```scala mdoc:compile-only
 // assume s: Session[IO]
-s.prepare(c).use { pc =>
+s.prepare(c).flatMap { pc =>
   pc.execute("xyzzy") *>
   pc.execute("fnord") *>
   pc.execute("blech")
@@ -81,7 +81,7 @@ If we're slighly more clever we can do this with `traverse` and return a list of
 
 ```scala mdoc:compile-only
 // assume s: Session[IO]
-s.prepare(c).use { pc =>
+s.prepare(c).flatMap { pc =>
   List("xyzzy", "fnord", "blech").traverse(s => pc.execute(s))
 } // IO[List[Completion]]
 ```
@@ -163,14 +163,14 @@ We can pass `pairs` to `execute`.
 
 ```scala mdoc:compile-only
 // assume s: Session[IO]
-s.prepare(insertPairs).use { pc => pc.execute(pairs) }
+s.prepare(insertPairs).flatMap { pc => pc.execute(pairs) }
 ```
 
 However attempting to pass anything *other than* `pairs` is a type error.
 
 ```scala mdoc:fail
 // assume s: Session[IO]
-s.prepare(insertPairs).use { pc => pc.execute(pairs.drop(1)) }
+s.prepare(insertPairs).flatMap { pc => pc.execute(pairs.drop(1)) }
 ```
 
 See the full example below for a demonstration of these techniques.
@@ -231,12 +231,10 @@ object PetService {
       .gmap[Pet]
 
   // construct a PetService
-  def fromSession[F[_]](s: Session[F])(
-    implicit ev: MonadCancel[F, Throwable]
-  ): PetService[F] =
+  def fromSession[F[_]: Monad](s: Session[F]): PetService[F] =
     new PetService[F] {
-      def insert(pet: Pet): F[Unit] = s.prepare(insertOne).use(_.execute(pet)).void
-      def insert(ps: List[Pet]): F[Unit] = s.prepare(insertMany(ps)).use(_.execute(ps)).void
+      def insert(pet: Pet): F[Unit] = s.prepare(insertOne).flatMap(_.execute(pet)).void
+      def insert(ps: List[Pet]): F[Unit] = s.prepare(insertMany(ps)).flatMap(_.execute(ps)).void
       def selectAll: F[List[Pet]] = s.execute(all)
     }
 

--- a/modules/docs/src/main/paradox/tutorial/Query.md
+++ b/modules/docs/src/main/paradox/tutorial/Query.md
@@ -175,7 +175,7 @@ Note that when using `Resource` and `Stream` together it is often convenient to 
 // assume s: Session[IO]
 val stream: Stream[IO, Unit] =
   for {
-    ps <- Stream.resource(s.prepare(e))
+    ps <- Stream.eval(s.prepare(e))
     c  <- ps.stream("U%", 64)
     _  <- Stream.eval(IO.println(c))
   } yield ()
@@ -357,7 +357,7 @@ object Service {
     """.query(varchar ~ bpchar(3) ~ int4)
        .gmap[Country]
 
-  def fromSession[F[_]: Applicative](s: Session[F]): Resource[F, Service[F]] =
+  def fromSession[F[_]: Applicative](s: Session[F]): F[Service[F]] =
     s.prepare(countries).map { pq =>
 
       // Our service implementation. Note that we are preparing the query on construction, so
@@ -384,7 +384,7 @@ object QueryExample2 extends IOApp {
 
   // A source of services
   val service: Resource[IO, Service[IO]] =
-    session.flatMap(Service.fromSession(_))
+    session.mapEval(Service.fromSession(_))
 
   // our entry point ... there is no indication that we're using a database at all!
   def run(args: List[String]): IO[ExitCode] =

--- a/modules/docs/src/main/paradox/tutorial/Query.md
+++ b/modules/docs/src/main/paradox/tutorial/Query.md
@@ -159,7 +159,7 @@ Here we use the extended query protocol to stream directly to the console using 
 
 ```scala mdoc:compile-only
 // assume s: Session[IO]
-s.prepare(e).use { ps =>
+s.prepare(e).flatMap { ps =>
   ps.stream("U%", 64)
     .evalMap(c => IO.println(c))
     .compile
@@ -213,7 +213,7 @@ Observe that we have two parameter encoders `varchar` and `int4` (in that order)
 
 ```scala mdoc:compile-only
 // assume s: Session[IO]
-s.prepare(f).use { ps =>
+s.prepare(f).flatMap { ps =>
   ps.stream("U%" ~ 2000000, 64)
     .evalMap(c => IO.println(c))
     .compile
@@ -292,7 +292,7 @@ object QueryExample extends IOApp {
 
   // run our extended query
   def doExtended(s: Session[IO]): IO[Unit] =
-    s.prepare(extended).use { ps =>
+    s.prepare(extended).flatMap { ps =>
       ps.stream("U%", 32)
         .evalMap(c => IO.println(c))
         .compile

--- a/modules/docs/src/main/paradox/tutorial/Query.md
+++ b/modules/docs/src/main/paradox/tutorial/Query.md
@@ -325,6 +325,7 @@ println("```")
 In real life a program like `QueryExample` above will grow complicated an hard to maintain because the database abstractions are out in the open. It's better to define an interface that *uses* a database session and write your program in terms of that interface. Here is a rewritten version of the program above that demonstrates this pattern.
 
 ```scala mdoc:reset
+import cats.syntax.all._
 import cats.effect._
 import skunk._
 import skunk.implicits._
@@ -384,7 +385,7 @@ object QueryExample2 extends IOApp {
 
   // A source of services
   val service: Resource[IO, Service[IO]] =
-    session.mapEval(Service.fromSession(_))
+    session.evalMap(Service.fromSession(_))
 
   // our entry point ... there is no indication that we're using a database at all!
   def run(args: List[String]): IO[ExitCode] =

--- a/modules/docs/src/main/paradox/tutorial/Transactions.md
+++ b/modules/docs/src/main/paradox/tutorial/Transactions.md
@@ -131,7 +131,7 @@ object PetService {
       .gmap[Pet]
 
   // construct a PetService, preparing our statement once on construction
-  def fromSession(s: Session[IO]): Resource[IO, PetService[IO]] =
+  def fromSession(s: Session[IO]): IO[PetService[IO]] =
     s.prepare(insertOne).map { pc =>
       new PetService[IO] {
 
@@ -196,7 +196,7 @@ object TransactionExample extends IOApp {
       s  <- session
       _  <- withPetsTable(s)
       _  <- withTransactionStatusLogger(s)
-      ps <- PetService.fromSession(s)
+      ps <- Resource.eval(PetService.fromSession(s))
     } yield ps
 
   // Some test data

--- a/modules/example/src/main/scala/AppliedFragments.scala
+++ b/modules/example/src/main/scala/AppliedFragments.scala
@@ -59,7 +59,7 @@ object AppliedFragments extends IOApp {
       _  <- IO(println(s"\nargs: $name, $pop, $capital"))
       af  = countryQuery(name, pop, capital)
       _ <- IO(println(af.fragment.sql))
-      _ <- s.prepare(af.fragment.query(country)).use(_.stream(af.argument, 64).take(5).evalMap(c => IO(println(c))).compile.drain)
+      _ <- s.prepare(af.fragment.query(country)).flatMap(_.stream(af.argument, 64).take(5).evalMap(c => IO(println(c))).compile.drain)
     } yield ()
 
   def run(args: List[String]): IO[ExitCode] =

--- a/modules/example/src/main/scala/Error.scala
+++ b/modules/example/src/main/scala/Error.scala
@@ -31,7 +31,7 @@ object Error extends IOApp {
     """.query(varchar ~ int4)
 
   def prog[F[_]](s: Session[F])(implicit ev: MonadCancel[F, Throwable]): F[ExitCode] =
-    s.prepare(query).use(_.unique("foo" ~ 1000000)).as(ExitCode.Success)
+    s.prepare(query).flatMap(_.unique("foo" ~ 1000000)).as(ExitCode.Success)
 
   def run(args: List[String]): IO[ExitCode] =
     session.use(prog(_))

--- a/modules/example/src/main/scala/Join.scala
+++ b/modules/example/src/main/scala/Join.scala
@@ -49,10 +49,10 @@ object Join extends IOApp with StreamOps {
         ORDER BY country.code, city.name ASC
       """.query((varchar ~ bpchar(3) ~ int4) ~ (varchar ~ int4).gmap[City].opt)
 
-    def fromSession[F[_]: MonadCancelThrow](s: Session[F]): WorldService[F] =
+    def fromSession[F[_]](s: Session[F]): WorldService[F] =
       new WorldService[F] {
         def countriesByName(pat: Pattern): Stream[F,Country] =
-          Stream.resource(s.prepare(countriesByNameQuery)).flatMap { cs =>
+          Stream.eval(s.prepare(countriesByNameQuery)).flatMap { cs =>
             cs.stream(pat, 64)
               .chunkAdjacent
               .map { case ((name ~ code ~ pop), chunk) =>

--- a/modules/example/src/main/scala/Main.scala
+++ b/modules/example/src/main/scala/Main.scala
@@ -83,12 +83,12 @@ object Main extends IOApp {
           _   <- s.execute(sql"set client_encoding = ISO8859_1".command)
           _   <- s.channel(id"foo").notify("here is a message")
           _   <- s.execute(sql"select current_user".query(name))
-          _   <- s.prepare(q).use(hmm(_))
-          _   <- s.prepare(in(3)).use { _.stream(List("FRA", "USA", "GAB"), 100).through(anyLinesStdOut).compile.drain }
+          _   <- s.prepare(q).flatMap(hmm(_))
+          _   <- s.prepare(in(3)).flatMap { _.stream(List("FRA", "USA", "GAB"), 100).through(anyLinesStdOut).compile.drain }
           _   <- f2.cancel // otherwise it will run forever
           _   <- f1.cancel // otherwise it will run forever
           _   <- s.execute(sql"select 'x'::bpchar(10)".query(bpchar(10)))
-          _   <- s.prepare(sql"select 1".query(int4)).use { _.stream(Void, 10).through(anyLinesStdOut).compile.drain }
+          _   <- s.prepare(sql"select 1".query(int4)).flatMap { _.stream(Void, 10).through(anyLinesStdOut).compile.drain }
           _   <- putStrLn("Done.")
         } yield ExitCode.Success
       } *>

--- a/modules/example/src/main/scala/Math1.scala
+++ b/modules/example/src/main/scala/Math1.scala
@@ -5,6 +5,7 @@
 package example
 
 import cats.effect._
+import cats.syntax.all._
 import skunk.Session
 import skunk.implicits._
 import skunk.codec.numeric.{ int4, float8 }
@@ -39,8 +40,8 @@ object Math1 extends IOApp {
       implicit ev: MonadCancel[F, Throwable]
     ): Math[F] =
       new Math[F] {
-        def add(a: Int, b: Int) = sess.prepare(Statements.add).use(_.unique(a ~ b))
-        def sqrt(d: Double)     = sess.prepare(Statements.sqrt).use(_.unique(d))
+        def add(a: Int, b: Int) = sess.prepare(Statements.add).flatMap(_.unique(a ~ b))
+        def sqrt(d: Double)     = sess.prepare(Statements.sqrt).flatMap(_.unique(d))
       }
 
   }

--- a/modules/example/src/main/scala/Math2.scala
+++ b/modules/example/src/main/scala/Math2.scala
@@ -4,7 +4,9 @@
 
 package example
 
+import cats.Monad
 import cats.effect.{ ExitCode, IO, IOApp, Resource }
+import cats.syntax.all._
 import skunk.Session
 import skunk.implicits._
 import skunk.codec.numeric.{ int4, float8 }
@@ -35,7 +37,7 @@ object Math2 extends IOApp {
       val sqrt = sql"select sqrt($float8)".query(float8)
     }
 
-    def fromSession[F[_]](sess: Session[F]): Resource[F, Math[F]] =
+    def fromSession[F[_]: Monad](sess: Session[F]): F[Math[F]] =
       for {
         pAdd  <- sess.prepare(Statements.add)
         pSqrt <- sess.prepare(Statements.sqrt)
@@ -48,7 +50,7 @@ object Math2 extends IOApp {
   }
 
   def run(args: List[String]): IO[ExitCode] =
-    session.flatMap(Math.fromSession(_)).use { m =>
+    session.evalMap(Math.fromSession(_)).use { m =>
       for {
         n  <- m.add(42, 71)
         d  <- m.sqrt(2)

--- a/modules/example/src/main/scala/Minimal2.scala
+++ b/modules/example/src/main/scala/Minimal2.scala
@@ -45,7 +45,7 @@ object Minimal2 extends IOApp {
   def lookup[F[_]: Async: Trace](pat: String, s: Session[F]): F[Unit] =
     Trace[F].span("lookup") {
       Trace[F].put("pattern" -> pat) *>
-      s.prepare(select).use { pq =>
+      s.prepare(select).flatMap { pq =>
         pq.stream(pat, 1024)
           .evalMap(c => Sync[F].delay(println(s"⭐️⭐  $c")))
           .compile

--- a/modules/example/src/main/scala/Minimal3.scala
+++ b/modules/example/src/main/scala/Minimal3.scala
@@ -36,7 +36,7 @@ object Minimal3 extends IOApp {
   def stream(pattern: String): Stream[IO, Country] =
     for {
       s  <- resource(session)
-      pq <- resource(s.prepare(select))
+      pq <- Stream.eval(s.prepare(select))
       c  <- pq.stream(pattern, 8)
     } yield c
 

--- a/modules/example/src/main/scala/Values.scala
+++ b/modules/example/src/main/scala/Values.scala
@@ -41,7 +41,7 @@ object Values extends IOApp {
   def run(args: List[String]): IO[ExitCode] =
     session.use { s =>
       val q = query(examples.length)
-      s.prepare(q).use { pq =>
+      s.prepare(q).flatMap { pq =>
         for {
           _  <- IO(println(q.sql))
           ds <- pq.stream(examples, 64).compile.to(List)

--- a/modules/tests/shared/src/test/scala/CommandTest.scala
+++ b/modules/tests/shared/src/test/scala/CommandTest.scala
@@ -260,38 +260,38 @@ class CommandTest extends SkunkTest {
 
   sessionTest("insert, update and delete record") { s =>
     for {
-      c <- s.prepare(insertCity).use(_.execute(Garin))
+      c <- s.prepare(insertCity).flatMap(_.execute(Garin))
       _ <- assert("completion",  c == Completion.Insert(1))
-      c <- s.prepare(selectCity).use(_.unique(Garin.id))
+      c <- s.prepare(selectCity).flatMap(_.unique(Garin.id))
       _ <- assert("read", c == Garin)
       p <- IO(Garin.pop + 1000)
-      c <- s.prepare(updateCityPopulation).use(_.execute(p ~ Garin.id))
+      c <- s.prepare(updateCityPopulation).flatMap(_.execute(p ~ Garin.id))
       _ <- assert("completion",  c == Completion.Update(1))
-      c <- s.prepare(selectCity).use(_.unique(Garin.id))
+      c <- s.prepare(selectCity).flatMap(_.unique(Garin.id))
       _ <- assert("read", c == Garin.copy(pop = p))
-      _ <- s.prepare(deleteCity).use(_.execute(Garin.id))
+      _ <- s.prepare(deleteCity).flatMap(_.execute(Garin.id))
       _ <- s.assertHealthy
     } yield "ok"
   }
 
   sessionTest("insert and delete record with contramapped command") { s =>
     for {
-      c <- s.prepare(insertCity2).use(_.execute(Garin2))
+      c <- s.prepare(insertCity2).flatMap(_.execute(Garin2))
       _ <- assert("completion",  c == Completion.Insert(1))
-      c <- s.prepare(selectCity).use(_.unique(Garin2.id))
+      c <- s.prepare(selectCity).flatMap(_.unique(Garin2.id))
       _ <- assert("read", c == Garin2)
-      _ <- s.prepare(deleteCity).use(_.execute(Garin2.id))
+      _ <- s.prepare(deleteCity).flatMap(_.execute(Garin2.id))
       _ <- s.assertHealthy
     } yield "ok"
   }
 
   sessionTest("insert and delete record with contramapped command (via Contravariant instance") { s =>
     for {
-      c <- s.prepare(insertCity2a).use(_.execute(Garin3))
+      c <- s.prepare(insertCity2a).flatMap(_.execute(Garin3))
       _ <- assert("completion",  c == Completion.Insert(1))
-      c <- s.prepare(selectCity).use(_.unique(Garin3.id))
+      c <- s.prepare(selectCity).flatMap(_.unique(Garin3.id))
       _ <- assert("read", c == Garin3)
-      _ <- s.prepare(deleteCity).use(_.execute(Garin3.id))
+      _ <- s.prepare(deleteCity).flatMap(_.execute(Garin3.id))
       _ <- s.assertHealthy
     } yield "ok"
   }
@@ -316,7 +316,7 @@ class CommandTest extends SkunkTest {
 
   sessionTest("should be a query") { s =>
     s.prepare(sql"select * from country".command)
-      .use(_ => IO.unit)
+      .flatMap(_ => IO.unit)
       .assertFailsWith[UnexpectedRowsException]
       .as("ok")
   }

--- a/modules/tests/shared/src/test/scala/CopyInTest.scala
+++ b/modules/tests/shared/src/test/scala/CopyInTest.scala
@@ -24,13 +24,13 @@ class CopyInTest extends SkunkTest {
 
   sessionTest("copy in (extended, query)") { s =>
     s.prepare(sql"COPY country FROM STDIN".query(int4))
-      .use { _ => IO.unit }
+      .flatMap { _ => IO.unit }
       .assertFailsWith[NoDataException] *> s.assertHealthy // can't distinguish this from other cases, probably will be an FAQ
   }
 
   sessionTest("copy in (extended command)") { s =>
     s.prepare(sql"COPY country FROM STDIN".command)
-      .use { _.execute(skunk.Void) }
+      .flatMap { _.execute(skunk.Void) }
       .assertFailsWith[CopyNotSupportedException] *> s.assertHealthy
   }
 

--- a/modules/tests/shared/src/test/scala/CopyOutTest.scala
+++ b/modules/tests/shared/src/test/scala/CopyOutTest.scala
@@ -24,13 +24,13 @@ class CopyOutTest extends SkunkTest {
 
   sessionTest("copy out (extended, query)") { s =>
     s.prepare(sql"COPY country TO STDOUT".query(int4))
-      .use { _ => IO.unit }
+      .flatMap { _ => IO.unit }
       .assertFailsWith[NoDataException] *> s.assertHealthy // can't distinguish this from other cases, probably will be an FAQ
   }
 
   sessionTest("copy out (extended command)") { s =>
     s.prepare(sql"COPY country TO STDOUT".command)
-      .use { _.execute(skunk.Void) }
+      .flatMap { _.execute(skunk.Void) }
       .assertFailsWith[CopyNotSupportedException] *> s.assertHealthy
   }
 

--- a/modules/tests/shared/src/test/scala/CursorTest.scala
+++ b/modules/tests/shared/src/test/scala/CursorTest.scala
@@ -16,7 +16,7 @@ class CursorTest extends SkunkTest {
   case class Data(s: String, n: Int)
 
   def cursor(s: Session[IO]): Resource[IO, Cursor[IO, Data]] =
-    s.prepare(sql"select name, population from country".query(varchar ~ int4))
+    s.prepareR(sql"select name, population from country".query(varchar ~ int4))
      .flatMap(_.cursor(Void).map { c =>
        c.map { case s ~ n => Data(s, n) } .mapK(FunctionK.id) // coverage
      })

--- a/modules/tests/shared/src/test/scala/DescribeCacheTest.scala
+++ b/modules/tests/shared/src/test/scala/DescribeCacheTest.scala
@@ -65,16 +65,16 @@ class DescribeCacheTest extends SkunkTest {
   sessionTest("command should not be cached if `prepare` fails") { s =>
     val cmd = sql"foo".command
     for {
-      _ <- s.prepare(cmd).use(_ => IO.unit).assertFailsWith[PostgresErrorException]
+      _ <- s.prepare(cmd).flatMap(_ => IO.unit).assertFailsWith[PostgresErrorException]
       c <- s.describeCache.commandCache.containsKey(cmd)
       _ <- assertEqual("should not be in cache", c, false)
     } yield "ok"
   }
 
-  sessionTest("command should be cached after `prepare.use`" ) { s =>
+  sessionTest("command should be cached after `prepare`" ) { s =>
     val cmd = sql"commit".command
     for {
-      _ <- s.prepare(cmd).use(_ => IO.unit)
+      _ <- s.prepare(cmd).flatMap(_ => IO.unit)
       c <- s.describeCache.commandCache.containsKey(cmd)
       _ <- assertEqual("should be in cache", c, true)
     } yield "ok"
@@ -83,7 +83,7 @@ class DescribeCacheTest extends SkunkTest {
   sessionTest("command should not be cached after cache is cleared") { s =>
     val cmd = sql"commit".command
     for {
-      _ <- s.prepare(cmd).use(_ => IO.unit)
+      _ <- s.prepare(cmd).flatMap(_ => IO.unit)
       c <- s.describeCache.commandCache.containsKey(cmd)
       _ <- assertEqual("should be in cache", c, true)
       _ <- s.describeCache.commandCache.clear
@@ -94,7 +94,7 @@ class DescribeCacheTest extends SkunkTest {
 
   // Queries
 
-  sessionTest("query should not be cached before `prepare.use`") { s =>
+  sessionTest("query should not be cached before `prepare`") { s =>
     val qry = sql"select 1".query(int4)
     for {
       c <- s.describeCache.queryCache.containsKey(qry)
@@ -105,16 +105,16 @@ class DescribeCacheTest extends SkunkTest {
   sessionTest("query should not be cached if `prepare` fails") { s =>
     val qry = sql"foo".query(int4)
     for {
-      _ <- s.prepare(qry).use(_ => IO.unit).assertFailsWith[PostgresErrorException]
+      _ <- s.prepare(qry).flatMap(_ => IO.unit).assertFailsWith[PostgresErrorException]
       c <- s.describeCache.commandCache.containsKey(qry)
       _ <- assertEqual("should not be in cache", c, false)
     } yield "ok"
   }
 
-  sessionTest("query should be cached after `prepare.use`" ) { s =>
+  sessionTest("query should be cached after `prepare`" ) { s =>
     val qry = sql"select 1".query(int4)
     for {
-      _ <- s.prepare(qry).use(_ => IO.unit)
+      _ <- s.prepare(qry).flatMap(_ => IO.unit)
       c <- s.describeCache.queryCache.containsKey(qry)
       _ <- assertEqual("should be in cache", c, true)
     } yield "ok"
@@ -123,7 +123,7 @@ class DescribeCacheTest extends SkunkTest {
   sessionTest("query should not be cached after cache is cleared") { s =>
     val qry = sql"select 1".query(int4)
     for {
-      _ <- s.prepare(qry).use(_ => IO.unit)
+      _ <- s.prepare(qry).flatMap(_ => IO.unit)
       c <- s.describeCache.queryCache.containsKey(qry)
       _ <- assertEqual("should be in cache", c, true)
       _ <- s.describeCache.queryCache.clear

--- a/modules/tests/shared/src/test/scala/EmptyStatementTest.scala
+++ b/modules/tests/shared/src/test/scala/EmptyStatementTest.scala
@@ -28,12 +28,12 @@ class EmptyStatementTest extends SkunkTest {
   }
 
   sessionTest("empty query (extended query)") { s =>
-    s.prepare(sql"".query(int4)).use(_ => IO.unit)
+    s.prepare(sql"".query(int4)).flatMap(_ => IO.unit)
       .assertFailsWith[NoDataException] *> s.assertHealthy
   }
 
   sessionTest("empty query (extended command)") { s =>
-    s.prepare(sql"".command).use(_.execute(skunk.Void))
+    s.prepare(sql"".command).flatMap(_.execute(skunk.Void))
       .assertFailsWith[EmptyStatementException] *> s.assertHealthy
   }
 

--- a/modules/tests/shared/src/test/scala/ErrorResponseTest.scala
+++ b/modules/tests/shared/src/test/scala/ErrorResponseTest.scala
@@ -31,14 +31,14 @@ class ErrorResponseTest extends SkunkTest {
 
   sessionTest("prepared query, syntax error") { s =>
     for {
-      _ <- s.prepare(sql"foo?".query(int4)).use(_ => IO.unit).assertFailsWith[PostgresErrorException]
+      _ <- s.prepare(sql"foo?".query(int4)).flatMap(_ => IO.unit).assertFailsWith[PostgresErrorException]
       _ <- s.assertHealthy
     } yield "ok"
   }
 
   sessionTest("prepared command, syntax error") { s =>
     for {
-      _ <- s.prepare(sql"foo?".command).use(_ => IO.unit).assertFailsWith[PostgresErrorException]
+      _ <- s.prepare(sql"foo?".command).flatMap(_ => IO.unit).assertFailsWith[PostgresErrorException]
       _ <- s.assertHealthy
     } yield "ok"
   }

--- a/modules/tests/shared/src/test/scala/FragmentTest.scala
+++ b/modules/tests/shared/src/test/scala/FragmentTest.scala
@@ -13,7 +13,7 @@ class FragmentTest extends SkunkTest {
 
   sessionTest("contramap") { s =>
     val f = sql"select $int4".contramap[String](_.toInt)
-    s.prepare(f.query(int4)).use { ps =>
+    s.prepare(f.query(int4)).flatMap { ps =>
       for {
         n <- ps.unique("123")
         _ <- assertEqual("123", n, 123)
@@ -23,7 +23,7 @@ class FragmentTest extends SkunkTest {
 
   sessionTest("product") { s =>
     val f = sql"select $int4" product sql", $varchar"
-    s.prepare(f.query(int4 ~ varchar)).use { ps =>
+    s.prepare(f.query(int4 ~ varchar)).flatMap { ps =>
       for {
         n <- ps.unique(123 ~ "456")
         _ <- assertEqual("123 ~ \"456\"", n, 123 ~ "456")
@@ -33,7 +33,7 @@ class FragmentTest extends SkunkTest {
 
   sessionTest("~") { s =>
     val f = sql"select $int4" ~ sql", $varchar"
-    s.prepare(f.query(int4 ~ varchar)).use { ps =>
+    s.prepare(f.query(int4 ~ varchar)).flatMap { ps =>
       for {
         n <- ps.unique(123 ~ "456")
         _ <- assertEqual("123 ~ \"456\"", n, 123 ~ "456")
@@ -43,7 +43,7 @@ class FragmentTest extends SkunkTest {
 
   sessionTest("contramap via ContravariantSemigroupal") { s =>
     val f = ContravariantSemigroupal[Fragment].contramap[Int, String](sql"select $int4")(_.toInt)
-    s.prepare(f.query(int4)).use { ps =>
+    s.prepare(f.query(int4)).flatMap { ps =>
       for {
         n <- ps.unique("123")
         _ <- assertEqual("123", n, 123)
@@ -53,7 +53,7 @@ class FragmentTest extends SkunkTest {
 
   sessionTest("product via ContravariantSemigroupal") { s =>
     val f = ContravariantSemigroupal[Fragment].product(sql"select $int4", sql", $varchar")
-    s.prepare(f.query(int4 ~ varchar)).use { ps =>
+    s.prepare(f.query(int4 ~ varchar)).flatMap { ps =>
       for {
         n <- ps.unique(123 ~ "456")
         _ <- assertEqual("123 ~ \"456\"", n, 123 ~ "456")

--- a/modules/tests/shared/src/test/scala/ListTest.scala
+++ b/modules/tests/shared/src/test/scala/ListTest.scala
@@ -18,7 +18,7 @@ class ListTest extends SkunkTest {
       sql"SELECT * FROM (VALUES $aLotOfStringsCodec) AS tmp LIMIT 1".query(text)
 
     for {
-      res <- s.prepare(bigValuesCommand).use(q => q.unique(aLotOfStrings))
+      res <- s.prepare(bigValuesCommand).flatMap(q => q.unique(aLotOfStrings))
       _ <- assert("read", res == "foo")
       _ <- s.assertHealthy
     } yield "ok"

--- a/modules/tests/shared/src/test/scala/MultipleStatementsTest.scala
+++ b/modules/tests/shared/src/test/scala/MultipleStatementsTest.scala
@@ -28,13 +28,13 @@ class MultipleStatementsTest extends SkunkTest {
 
   sessionTest("extended query (postgres raises an error here)") { s =>
     s.prepare(sql"select 1;commit".query(int4))
-      .use(_ => IO.unit)
+      .flatMap(_ => IO.unit)
       .assertFailsWith[PostgresErrorException] *> s.assertHealthy
   }
 
   sessionTest("extended command (postgres raises an error here)") { s =>
     s.prepare(sql"select 1;commit".command)
-      .use(_ => IO.unit)
+      .flatMap(_ => IO.unit)
       .assertFailsWith[PostgresErrorException] *> s.assertHealthy
   }
 

--- a/modules/tests/shared/src/test/scala/QueryTest.scala
+++ b/modules/tests/shared/src/test/scala/QueryTest.scala
@@ -19,7 +19,7 @@ class QueryTest extends SkunkTest{
 
     sessionTest("map") { s =>
         val f = sql"select $int4"
-        s.prepare(f.query(int4).map(_.toString)).use { ps =>
+        s.prepare(f.query(int4).map(_.toString)).flatMap { ps =>
             for {
                 n <- ps.unique(123)
                 _ <- assertEqual("123", n, "123")
@@ -29,7 +29,7 @@ class QueryTest extends SkunkTest{
 
     sessionTest("gmap") { s =>
         val f = sql"select $int4"
-        s.prepare(f.query(int4).gmap[Number]).use { ps =>
+        s.prepare(f.query(int4).gmap[Number]).flatMap { ps =>
             for {
                 n <- ps.unique(123)
                 _ <- assertEqual("123", n, Number(123))
@@ -39,7 +39,7 @@ class QueryTest extends SkunkTest{
 
     sessionTest("contramap") { s =>
         val f = sql"select $int4"
-        s.prepare(f.query(int4).contramap[String](_.toInt)).use { ps =>
+        s.prepare(f.query(int4).contramap[String](_.toInt)).flatMap { ps =>
             for {
                 n <- ps.unique("123")
                 _ <- assertEqual("123", n, 123)
@@ -49,7 +49,7 @@ class QueryTest extends SkunkTest{
 
     sessionTest("gcontramap") { s =>
         val f = sql"select $int4"
-        s.prepare(f.query(int4).gcontramap[Number]).use { ps =>
+        s.prepare(f.query(int4).gcontramap[Number]).flatMap { ps =>
             for {
                 n <- ps.unique(Number(123))
                 _ <- assertEqual("123", n, 123)
@@ -70,7 +70,7 @@ class QueryTest extends SkunkTest{
         }
         for {
             sessionBroken <- getS.use { s =>
-                s.prepare(f.query(void)).use { ps =>
+                s.prepare(f.query(void)).flatMap { ps =>
                     for {
                         ret <- ps.unique(8).attempt
                         _ <- assertEqual("timeout error check", getErr(ret), Option("2 seconds"))
@@ -79,7 +79,7 @@ class QueryTest extends SkunkTest{
             }.attempt
             _ <- assertEqual("timeout error check", getErr(sessionBroken), Option("2 seconds"))
             _ <- getS.use { s =>
-                s.prepare(f.query(void)).use { ps =>
+                s.prepare(f.query(void)).flatMap { ps =>
                     for {
                         ret <- ps.unique(1).attempt
                         _ <- assertEqual("timeout error ok", ret.isRight, true)

--- a/modules/tests/shared/src/test/scala/codec/CodecTest.scala
+++ b/modules/tests/shared/src/test/scala/codec/CodecTest.scala
@@ -37,7 +37,7 @@ abstract class CodecTest(
     }).asInstanceOf[Fragment[A]] // macro doesn't quite work in dotty yet
 
     sessionTest(s"${codec.types.mkString(", ")}") { s =>
-      s.prepare(sqlString.query(codec)).use { ps =>
+      s.prepare(sqlString.query(codec)).flatMap { ps =>
         as.toList.traverse { a =>
           for {
             aʹ <- ps.unique(a)
@@ -48,7 +48,7 @@ abstract class CodecTest(
     }
 
     sessionTest(s"${codec.types.mkString(", ")} (gmap)") { s =>
-      s.prepare(sqlString.query(codec.gmap[Box[A]])).use { ps =>
+      s.prepare(sqlString.query(codec.gmap[Box[A]])).flatMap { ps =>
         as.toList.traverse { a =>
           for {
             aʹ <- ps.unique(a)
@@ -63,7 +63,7 @@ abstract class CodecTest(
   // Test a specific special value like NaN where equals doesn't work
   def roundtripWithSpecialValueTest[A](name: String, codec: Codec[A], ascription: Option[String] = None)(value: A, isOk: A => Boolean): Unit =
     sessionTest(s"${codec.types.mkString(",")}") { s =>
-      s.prepare(sql"select $codec#${ascription.foldMap("::" + _)}".asInstanceOf[Fragment[A]].query(codec)).use { ps =>
+      s.prepare(sql"select $codec#${ascription.foldMap("::" + _)}".asInstanceOf[Fragment[A]].query(codec)).flatMap { ps =>
         ps.unique(value).flatMap { a =>
           assert(name, isOk(a)).as(name)
         }

--- a/modules/tests/shared/src/test/scala/exception/TooManyParametersExceptionTest.scala
+++ b/modules/tests/shared/src/test/scala/exception/TooManyParametersExceptionTest.scala
@@ -15,11 +15,11 @@ class TooManyParametersExceptionTest extends SkunkTest {
     def stmt(n: Int) = sql"select 1 where 1 in (${int4.list(n)})".query(int4)
 
     sessionTest(s"ok with ${Short.MaxValue} parameters.") { s =>
-      s.prepare(stmt(Short.MaxValue)).use { _ => IO("ok") }
+      s.prepare(stmt(Short.MaxValue)).flatMap { _ => IO("ok") }
     }
 
     sessionTest(s"raise TooManyParametersException when statement contains > ${Short.MaxValue} parameters") { s =>
-      s.prepare(stmt(Short.MaxValue + 1)).use { _ => IO.never }
+      s.prepare(stmt(Short.MaxValue + 1)).flatMap { _ => IO.never }
        .assertFailsWith[TooManyParametersException]
        .as("ok")
     }

--- a/modules/tests/shared/src/test/scala/issue/210.scala
+++ b/modules/tests/shared/src/test/scala/issue/210.scala
@@ -50,8 +50,8 @@ class Test210 extends SkunkTest {
   def doInserts(ready: Deferred[IO, Unit], done: Deferred[IO, Unit]): IO[Unit] =
     session.flatTap(withPetsTable).use { s =>
       for {
-        _ <- s.prepare(insertOne).use(pc => pc.execute(Pet("Bob", 12)))
-        _ <- s.prepare(insertMany(beatles)).use(pc => pc.execute(beatles))
+        _ <- s.prepare(insertOne).flatMap(pc => pc.execute(Pet("Bob", 12)))
+        _ <- s.prepare(insertMany(beatles)).flatMap(pc => pc.execute(beatles))
         _ <- ready.complete(())
         _ <- done.get // wait for main fiber to finish
       } yield ()

--- a/modules/tests/shared/src/test/scala/issue/313.scala
+++ b/modules/tests/shared/src/test/scala/issue/313.scala
@@ -30,7 +30,7 @@ class Test313 extends SkunkTest {
   sessionTest("issue/313") { s =>
     for {
       _  <- s.execute(sql"SET TIME ZONE +3".command)
-      i  <- s.prepare(sql"SELECT $instantCodec".query(instantCodec)).use(_.unique(instant))
+      i  <- s.prepare(sql"SELECT $instantCodec".query(instantCodec)).flatMap(_.unique(instant))
       _  <- assertEqual("instant roundtrip via timestamptz", instant, i)
     } yield "ok"
   }

--- a/modules/tests/shared/src/test/scala/issue/628.scala
+++ b/modules/tests/shared/src/test/scala/issue/628.scala
@@ -13,7 +13,7 @@ import tests.SkunkTest
 class Test628 extends SkunkTest {
 
   sessionTest("issue/628") { s =>
-    s.prepare(sql"select name from country".query(varchar)).use { ps =>
+    s.prepare(sql"select name from country".query(varchar)).flatMap { ps =>
       ps.stream(Void, 10).compile.toList
     }
   }

--- a/modules/tests/shared/src/test/scala/simulation/SimpleSimTest.scala
+++ b/modules/tests/shared/src/test/scala/simulation/SimpleSimTest.scala
@@ -51,7 +51,7 @@ class SimpleSimTest extends SimTest {
   }
 
   simTest("sim error", sim) { s =>
-    s.prepare(sql"select $int4".query(int4)).use(_ => IO.unit)
+    s.prepare(sql"select $int4".query(int4)).flatMap(_ => IO.unit)
      .assertFailsWith[PostgresErrorException]
      .as("ok")
   }


### PR DESCRIPTION
I believe this sets us up better for the future, though does require folks to either rewrite their code to use `F[..]` instead of `Resource[F, ..]` or otherwise add an `R` character after `prepare`.