### PR TITLE
disable redshift test if running on arm

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -192,7 +192,12 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.typelevel"     %%% "discipline-munit"        % "2.0.0-M3",
       "org.typelevel"     %%% "cats-time"               % "0.5.1",
     ),
-    testFrameworks += new TestFramework("munit.Framework")
+    testFrameworks += new TestFramework("munit.Framework"),
+    testOptions += {
+      if(System.getProperty("os.arch").startsWith("aarch64")) {
+        Tests.Argument(TestFrameworks.MUnit, "--exclude-tags=X86ArchOnly")
+      } else Tests.Argument()
+    }
   )
   .jsSettings(
     Test / scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),

--- a/modules/tests/shared/src/test/scala/RedshiftTest.scala
+++ b/modules/tests/shared/src/test/scala/RedshiftTest.scala
@@ -10,8 +10,9 @@ import skunk.exception.StartupException
 import natchez.Trace.Implicits.noop
 
 class RedshiftTest extends ffstest.FTest {
+  object X86ArchOnly extends munit.Tag("X86ArchOnly")
 
-  test("redshift - successfully connect") {
+  test("redshift - successfully connect".tag(X86ArchOnly)) {
     Session.single[IO](
       host = "localhost",
       user = "postgres",
@@ -22,7 +23,7 @@ class RedshiftTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  test("redshift - cannot connect with default params") {
+  test("redshift - cannot connect with default params".tag(X86ArchOnly)) {
     Session.single[IO](
       host = "localhost",
       user = "postgres",


### PR DESCRIPTION
resolves #748 

Please let me know if you would like me to move tag out of the test into something like `tests.tags.X86ArchOnly` or any other changes are required