### PR TITLE
Mirrored session apis for parametrized queries

### DIFF
--- a/modules/core/shared/src/main/scala/Session.scala
+++ b/modules/core/shared/src/main/scala/Session.scala
@@ -10,6 +10,7 @@ import cats.effect.std.Console
 import cats.syntax.all._
 import fs2.concurrent.Signal
 import fs2.io.net.{ Network, SocketGroup, SocketOption }
+import fs2.Compiler
 import fs2.Pipe
 import fs2.Stream
 import natchez.Trace
@@ -108,11 +109,29 @@ trait Session[F[_]] {
   def execute[A](query: Query[Void, A]): F[List[A]]
 
   /**
+   * Prepare if needed, then execute a parameterized query and yield all results. If you wish to limit
+   * returned rows use `prepare` instead.
+   *
+   * @group Queries
+   */
+  def execute[A, B](query: Query[A, B], args: A)(implicit F: Monad[F], c: Compiler[F,F]): F[List[B]] =
+    Monad[F].flatMap(prepare(query))(pq => pq.stream(args, Int.MaxValue).compile.toList)
+
+  /**
    * Execute a non-parameterized query and yield exactly one row, raising an exception if there are
    * more or fewer. If you have parameters use `prepare` instead.
    * @group Queries
    */
   def unique[A](query: Query[Void, A]): F[A]
+
+  /**
+   * Prepare if needed, then execute a parameterized query and yield exactly one row, raising an exception if there are
+   * more or fewer.
+   *
+   * @group Queries
+   */
+  def unique[A, B](query: Query[A, B], args: A)(implicit F: Monad[F]): F[B] =
+    Monad[F].flatMap(prepare(query))(_.unique(args))
 
   /**
    * Execute a non-parameterized query and yield at most one row, raising an exception if there are
@@ -122,11 +141,29 @@ trait Session[F[_]] {
   def option[A](query: Query[Void, A]): F[Option[A]]
 
   /**
+   * Prepare if needed, then execute a parameterized query and yield at most one row, raising an exception if there are
+   * more.
+   *
+   * @group Queries
+   */
+  def option[A, B](query: Query[A, B], args: A)(implicit F: Monad[F]): F[Option[B]] =
+    Monad[F].flatMap(prepare(query))(_.option(args))
+
+  /**
    * Execute a non-parameterized command and yield a `Completion`. If you have parameters use
    * `prepare` instead.
    * @group Commands
    */
   def execute(command: Command[Void]): F[Completion]
+
+  /**
+   * Prepare if needed, then execute a parameterized command and yield a `Completion`.
+   *
+   * @group Commands
+   */
+  def execute[A](command: Command[A], args: A)(implicit F: Monad[F]): F[Completion] =
+    Monad[F].flatMap(prepare(command))(_.execute(args))
+
   /**
    * Prepares then caches a query, yielding a `PreparedQuery` which can be executed multiple
    * times with different arguments.
@@ -169,7 +206,17 @@ trait Session[F[_]] {
    * Transform a `Command` into a `Pipe` from inputs to `Completion`s.
    * @group Commands
    */
-  def pipe[A](command: Command[A]): Pipe[F, A, Completion]
+  def pipe[A](command: Command[A]): Pipe[F, A, Completion] = fa =>
+    Stream.eval(prepare(command)).flatMap(pc => fa.evalMap(pc.execute)).scope
+
+  /**
+   * Transform a `Query` into a `Pipe` from inputs to outputs.
+   *
+   * @param chunkSize how many rows must be fetched by page 
+   * @group Commands
+   */
+  def pipe[A, B](query: Query[A, B], chunkSize: Int): Pipe[F, A, B] = fa =>
+    Stream.eval(prepare(query)).flatMap(pq => fa.flatMap(a => pq.stream(a, chunkSize))).scope
 
   /**
    * A named asynchronous channel that can be used for inter-process communication.
@@ -426,9 +473,6 @@ object Session {
 
         override def execute[A](query: Query[Void, A]): F[List[A]] =
           proto.execute(query, typer)
-
-        override def pipe[A](command: Command[A]): Pipe[F, A, Completion] = fa =>
-          Stream.eval(prepare(command)).flatMap(pc => fa.evalMap(pc.execute)).scope
 
         override def unique[A](query: Query[Void, A]): F[A] =
           execute(query).flatMap {

--- a/modules/tests/shared/src/test/scala/CommandTest.scala
+++ b/modules/tests/shared/src/test/scala/CommandTest.scala
@@ -260,16 +260,16 @@ class CommandTest extends SkunkTest {
 
   sessionTest("insert, update and delete record") { s =>
     for {
-      c <- s.prepare(insertCity).flatMap(_.execute(Garin))
+      c <- s.execute(insertCity, Garin)
       _ <- assert("completion",  c == Completion.Insert(1))
-      c <- s.prepare(selectCity).flatMap(_.unique(Garin.id))
+      c <- s.unique(selectCity, Garin.id)
       _ <- assert("read", c == Garin)
       p <- IO(Garin.pop + 1000)
-      c <- s.prepare(updateCityPopulation).flatMap(_.execute(p ~ Garin.id))
+      c <- s.execute(updateCityPopulation, p ~ Garin.id)
       _ <- assert("completion",  c == Completion.Update(1))
-      c <- s.prepare(selectCity).flatMap(_.unique(Garin.id))
+      c <- s.unique(selectCity, Garin.id)
       _ <- assert("read", c == Garin.copy(pop = p))
-      _ <- s.prepare(deleteCity).flatMap(_.execute(Garin.id))
+      _ <- s.execute(deleteCity, Garin.id)
       _ <- s.assertHealthy
     } yield "ok"
   }

--- a/modules/tests/shared/src/test/scala/QueryTest.scala
+++ b/modules/tests/shared/src/test/scala/QueryTest.scala
@@ -4,12 +4,12 @@
 
 package test
 
+import skunk._
 import skunk.codec.all._
 import skunk.implicits._
 import tests.SkunkTest
 import cats.Eq
 import scala.concurrent.duration._
-import skunk.Decoder
 import skunk.data.Type
 
 class QueryTest extends SkunkTest{
@@ -17,7 +17,47 @@ class QueryTest extends SkunkTest{
     case class Number(value: Int)
     implicit val numberEq: Eq[Number] = Eq.by(_.value)
 
-    sessionTest("map") { s =>
+    sessionTest("unique") { s =>
+      val query = sql"select * from (values ($int4), ($int4), ($int4)) as t(i) limit 1".query(int4)
+      for {
+        n <- s.unique(query, 123 ~ 456 ~ 789)
+        _ <- assertEqual("123", n, 123)
+      } yield "ok"
+    }
+
+    sessionTest("option - Some") { s =>
+      val query = sql"select * from (values ($int4), ($int4), ($int4)) as t(i) limit 1".query(int4)
+      for {
+        n <- s.option(query, 123 ~ 456 ~ 789)
+        _ <- assertEqual("123", n, Some(123))
+      } yield "ok"
+    }
+
+    sessionTest("option - None") { s =>
+      val query = sql"select * from (values ($int4), ($int4), ($int4)) as t(i) limit 0".query(int4)
+      for {
+        n <- s.option(query, 123 ~ 456 ~ 789)
+        _ <- assertEqual("123", n, None.asInstanceOf[Option[Int]])
+      } yield "ok"
+    }
+
+    sessionTest("list") { s =>
+      val query = sql"select * from (values ($int4), ($int4), ($int4)) as t(i)".query(int4)
+      for {
+        n <- fs2.Stream(1 ~ 2 ~ 3, 4 ~ 5 ~ 6, 7 ~ 8 ~ 9).through(s.pipe(query, 10)).compile.toList
+        _ <- assertEqual("123", n, List(1, 2, 3, 4, 5, 6, 7, 8, 9))
+      } yield "ok"
+    }
+
+    sessionTest("list") { s =>
+      val query = sql"select * from (values ($int4), ($int4), ($int4)) as t(i)".query(int4)
+      for {
+        n <- s.execute(query, 123 ~ 456 ~ 789)
+        _ <- assertEqual("123", n, List(123, 456, 789))
+      } yield "ok"
+    }
+
+  sessionTest("map") { s =>
         val f = sql"select $int4"
         s.prepare(f.query(int4).map(_.toString)).flatMap { ps =>
             for {


### PR DESCRIPTION
When running most OLTP queries, what we really need is to prepare the query if needed, then use the extended protocol to execute it.

This pr mirrors the session API for non-parametrized queries with parametrized counterparts prepared if not already in cache. It also add a fs2 pipe to transform a parametrized query to a pipe.

Some concerns : 
* The `Compiler` implicit for the `execute` method is not very nice, but using `MonadCancelThrow` is not either
* I moved the Command pipe to the trait since it can be implemented without override