### PR TITLE
Helpful handling of raw fragments

### DIFF
--- a/modules/core/shared/src/main/scala/Fragment.scala
+++ b/modules/core/shared/src/main/scala/Fragment.scala
@@ -42,6 +42,12 @@ final case class Fragment[A](
   def ~[B](fb: Fragment[B]): Fragment[A ~ B] =
     product(fb)
 
+  def ~>[B](fb: Fragment[B])(implicit ev: Void =:= A): Fragment[B] =
+    product(fb).contramap((Void, _))
+
+  def <~(fb: Fragment[Void]): Fragment[A] =
+    product(fb).contramap((_, Void))
+
   def stripMargin: Fragment[A] = stripMargin('|')
 
   def stripMargin(marginChar: Char): Fragment[A] = {

--- a/modules/tests/shared/src/test/scala/FragmentTest.scala
+++ b/modules/tests/shared/src/test/scala/FragmentTest.scala
@@ -41,6 +41,26 @@ class FragmentTest extends SkunkTest {
     }
   }
 
+  sessionTest("~>") { s =>
+    val f = sql"select" ~> sql" $int4, $varchar"
+    s.prepare(f.query(int4 ~ varchar)).flatMap { ps =>
+      for {
+        n <- ps.unique(123 ~ "456")
+        _ <- assertEqual("123 ~ \"456\"", n, 123 ~ "456")
+      } yield "ok"
+    }
+  }
+
+  sessionTest("<~") { s =>
+    val f = sql"select $int4" <~ sql", '456'"
+    s.prepare(f.query(int4 ~ text)).flatMap { ps =>
+      for {
+        n <- ps.unique(123)
+        _ <- assertEqual("123 ~ \"456\"", n, 123 ~ "456")
+      } yield "ok"
+    }
+  }
+
   sessionTest("contramap via ContravariantSemigroupal") { s =>
     val f = ContravariantSemigroupal[Fragment].contramap[Int, String](sql"select $int4")(_.toInt)
     s.prepare(f.query(int4)).flatMap { ps =>


### PR DESCRIPTION
This PR add two combinators to the `Fragment` class, to streamline combination if one of the operand is Fragment[Void].

Previous : 
```
(sql"SELECT id, name FROM users" ~ sql"where id = $int4" <~ sql"LIMIT 10").contramap(Void ~ _ ~ Void)
```

After : 
```
sql"SELECT id, name FROM users" ~> sql"where id = $int4" <~ sql"LIMIT 10"
```