### PR TITLE
Fix temporal codecs for years having less than 3 digits

### DIFF
--- a/modules/core/shared/src/main/scala/codec/TemporalCodecs.scala
+++ b/modules/core/shared/src/main/scala/codec/TemporalCodecs.scala
@@ -17,6 +17,7 @@ import java.time.temporal.ChronoField._
 import skunk.data.Type
 import java.time.temporal.TemporalAccessor
 import java.time.format.DateTimeFormatterBuilder
+import java.time.format.SignStyle
 import java.time.Duration
 import java.util.Locale
 
@@ -58,7 +59,7 @@ trait TemporalCodecs {
   // Instead we need to create custom formatters and append BC/AD after the date
   private val localDateFormatterWithoutEra: DateTimeFormatter =
     new DateTimeFormatterBuilder()
-      .appendValue(YEAR_OF_ERA)
+      .appendValue(YEAR_OF_ERA, 4, 19, SignStyle.NOT_NEGATIVE)
       .appendLiteral('-')
       .appendValue(MONTH_OF_YEAR, 2)
       .appendLiteral('-')

--- a/modules/tests/shared/src/test/scala/codec/TemporalCodecTest.scala
+++ b/modules/tests/shared/src/test/scala/codec/TemporalCodecTest.scala
@@ -33,6 +33,7 @@ class TemporalCodecTest extends CodecTest {
       LocalDate.of(-4713, 12, 31),  // Earliest date Postgres can store
       LocalDate.of(2019, 6, 17),    // A reasonable date.
       LocalDate.of(256789, 12, 31), // A very distant date
+      LocalDate.of(1, 2, 3),        // A date having a year with less than 3 digits
     )
 
   roundtripTest(date)(dates: _*)


### PR DESCRIPTION
Hello,

I noticed that the way skunk currently serializes dates doesn't pad the year to 4 digits.

This causes Postgres to interpret ` LocalDate.of(1, 2, 3)` (serialized as 1-02-03) as January 2nd 2003, instead of February 3rd 2001.
It also just raises an error in cases where the year is greater than 12 (because it interprets it as a month).

This fix just pads the year to 4 digits serializing ` LocalDate.of(1, 2, 3)` as 0001-02-03, which Postgres interprets correctly.