### PR TITLE
Update to latest otel4s dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,8 +60,8 @@ ThisBuild / tlFatalWarnings := false
 
 // This is used in a couple places
 lazy val fs2Version = "3.12.0"
-lazy val openTelemetryVersion = "1.44.1"
-lazy val otel4sVersion = "0.11.1"
+lazy val openTelemetryVersion = "1.52.0"
+lazy val otel4sVersion = "0.13.1"
 lazy val refinedVersion = "0.11.0"
 
 // Global Settings


### PR DESCRIPTION
```
java.lang.NoSuchMethodError: 'org.typelevel.otel4s.meta.InstrumentMeta org.typelevel.otel4s.trace.SpanBuilder.meta()'
	at skunk.util.Pool$.give$1(Pool.scala:88)
	at skunk.util.Pool$.poolImpl$1$$anonfun$1(Pool.scala:159)
	at cats.effect.kernel.Resource$.makeFull$$anonfun$1(Resource.scala:931)
	at cats.effect.IO$.bracketFull$$anonfun$1(IO.scala:1827)
	at cats.effect.IOFiber.runLoop(IOFiber.scala:568)
	at cats.effect.IOFiber.execR(IOFiber.scala:1397)
	at cats.effect.IOFiber.run(IOFiber.scala:122)
	at cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:928)
```

I think the issue comes from `Tracer.span` which is a macro and the method signature for `meta` has changed with latest otel4s version.