### PR TITLE
add GRANT ROLE, REVOKE ROLE, and ALTER DEFAULT PRIVILEGES completions

### DIFF
--- a/modules/core/shared/src/main/scala/data/Completion.scala
+++ b/modules/core/shared/src/main/scala/data/Completion.scala
@@ -72,6 +72,10 @@ object Completion {
   case object DropPolicy                extends Completion
   case object Comment                   extends Completion
   case object Analyze                   extends Completion
+  case object AlterDefaultPrivileges    extends Completion
+  case object GrantRole                 extends Completion
+  case object RevokeRole                extends Completion
+
   // more ...
 
   // weird Redshift variations

--- a/modules/core/shared/src/main/scala/net/message/CommandComplete.scala
+++ b/modules/core/shared/src/main/scala/net/message/CommandComplete.scala
@@ -111,6 +111,9 @@ object CommandComplete {
     case "ALTER POLICY"               => apply(Completion.AlterPolicy)
     case "DROP POLICY"                => apply(Completion.DropPolicy)
     case "ANALYZE"                    => apply(Completion.Analyze)
+    case "ALTER DEFAULT PRIVILEGES"   => apply(Completion.AlterDefaultPrivileges)
+    case "GRANT ROLE"                 => apply(Completion.GrantRole)
+    case "REVOKE ROLE"                => apply(Completion.RevokeRole)
     // more .. fill in as we hit them
 
     // weird Redshift variations

--- a/modules/tests/shared/src/test/scala/CommandTest.scala
+++ b/modules/tests/shared/src/test/scala/CommandTest.scala
@@ -664,4 +664,23 @@ class CommandTest extends SkunkTest {
     } yield "ok"
   }
 
+  sessionTestWithCleanup("grant role, revoke role") { s =>
+    for {
+      _ <- s.execute(createRole)
+      _ <- s.execute(sql"""CREATE ROLE skunk_role2""".command)
+      c <- s.execute(sql"""GRANT skunk_role2 TO skunk_role""".command)
+      _ <- assertEqual("completion", c, Completion.GrantRole)
+      c <- s.execute(sql"""REVOKE skunk_role2 FROM skunk_role""".command)
+      _ <- assertEqual("completion", c, Completion.RevokeRole)
+    } yield "ok"
+  }(sql"""DROP ROLE IF EXISTS skunk_role2""".command, dropRole)
+
+  sessionTest("alter default privileges") { s =>
+    for {
+      c <- s.execute(sql"""ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO PUBLIC""".command)
+      _ <- assertEqual("completion", c, Completion.AlterDefaultPrivileges)
+      _ <- s.assertHealthy
+    } yield "ok"
+  }
+
 }


### PR DESCRIPTION
Fixes #1237.

BTW, I wonder if [this Postgres source file](https://github.com/postgres/postgres/blob/630a93799d538c35c94187e07ef64d566a573a4e/src/include/tcop/cmdtaglist.h) contains the full list of command completions? If so, we could use that as a source to try to add any remaining completions we're missing.