### PR TITLE
Update SCRAM client to 3.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "com.beachape"  %%% "enumeratum"   % "1.9.0",
     ).filterNot(_ => tlIsScala3.value)
   ).jvmSettings(
-    libraryDependencies += "com.ongres.scram" % "client" % "2.1",
+    libraryDependencies += "com.ongres.scram" % "scram-client" % "3.2",
   ).platformsSettings(JSPlatform, NativePlatform)(
     libraryDependencies ++= Seq(
       "com.armanbilge" %%% "saslprep" % "0.1.2",

--- a/modules/core/jvm/src/main/scala/net/protocol/StartupPlatform.scala
+++ b/modules/core/jvm/src/main/scala/net/protocol/StartupPlatform.scala
@@ -5,7 +5,7 @@
 package skunk.net.protocol
 
 import com.ongres.scram.client.ScramClient
-import com.ongres.scram.common.stringprep.StringPreparations
+import com.ongres.scram.common.StringPreparation
 
 import cats.MonadError
 import cats.syntax.all._
@@ -19,7 +19,7 @@ import skunk.exception.{
 }
 
 private[protocol] trait StartupCompanionPlatform { this: Startup.type =>
-  
+
   private[protocol] def authenticationSASL[F[_]: MessageSocket: Tracer](
     sm:         StartupMessage,
     password:   Option[String],
@@ -28,34 +28,35 @@ private[protocol] trait StartupCompanionPlatform { this: Startup.type =>
     implicit ev: MonadError[F, Throwable]
   ): F[Unit] =
     Tracer[F].span("authenticationSASL").surround {
+        import scala.jdk.CollectionConverters._
+
         for {
+          pw <- requirePassword[F](sm, password)
           client <- {
-            try ScramClient.
-              channelBinding(ScramClient.ChannelBinding.NO).
-              stringPreparation(StringPreparations.SASL_PREPARATION).
-              selectMechanismBasedOnServerAdvertised(mechanisms.toArray: _*).
-              setup().pure[F]
+            try ScramClient.builder().
+              advertisedMechanisms(mechanisms.asJava).
+              username(sm.user).
+              password(pw.toCharArray).
+              stringPreparation(StringPreparation.POSTGRESQL_PREPARATION).
+              build().pure[F]
             catch {
               case _: IllegalArgumentException => new UnsupportedSASLMechanismsException(mechanisms).raiseError[F, ScramClient]
               case NonFatal(t) => new SCRAMProtocolException(t.getMessage).raiseError[F, ScramClient]
             }
           }
-          session = client.scramSession("*")
-          _ <- send(SASLInitialResponse(client.getScramMechanism.getName, bytesUtf8(session.clientFirstMessage)))
+          _ <- send(SASLInitialResponse(client.getScramMechanism.getName, bytesUtf8(client.clientFirstMessage().toString)))
           serverFirstBytes <- flatExpectStartup(sm) {
             case AuthenticationSASLContinue(serverFirstBytes) => serverFirstBytes.pure[F]
           }
-          serverFirst <- guardScramAction {
-            session.receiveServerFirstMessage(new String(serverFirstBytes.toArray, "UTF-8"))
+          _ <- guardScramAction {
+            client.serverFirstMessage(new String(serverFirstBytes.toArray, "UTF-8")).pure[F]
           }
-          pw <- requirePassword[F](sm, password)
-          clientFinal = serverFirst.clientFinalProcessor(pw)
-          _ <- send(SASLResponse(bytesUtf8(clientFinal.clientFinalMessage)))
+          _ <- send(SASLResponse(bytesUtf8(client.clientFinalMessage().toString)))
           serverFinalBytes <- flatExpectStartup(sm) {
             case AuthenticationSASLFinal(serverFinalBytes) => serverFinalBytes.pure[F]
           }
           _ <- guardScramAction {
-            clientFinal.receiveServerFinalMessage(new String(serverFinalBytes.toArray, "UTF-8")).pure[F]
+            client.serverFinalMessage(new String(serverFinalBytes.toArray, "UTF-8")).pure[F]
           }
           _ <- flatExpectStartup(sm) { case AuthenticationOk => ().pure[F] }
         } yield ()

--- a/modules/tests/shared/src/test/scala/simulation/StartupSimTest.scala
+++ b/modules/tests/shared/src/test/scala/simulation/StartupSimTest.scala
@@ -37,7 +37,7 @@ class StartupSimTest extends SimTest {
 
   test(s"unsupported sasl mechanism") {
     val sim = flatExpect { case StartupMessage(_, _, _) => send(AuthenticationSASL(List("Foo", "Bar"))) *> halt }
-    simSession(sim,"bob", "db", None)
+    simSession(sim,"bob", "db", Some("password"))
       .assertFailsWith[UnsupportedSASLMechanismsException]
       .as("ok")
   }


### PR DESCRIPTION
Bumps `"com.ongres.scram" % "client" % "2.1"` to `"com.ongres.scram" % "scram-client" % "3.2"`. 

This resolves dependency conflicts for users who also have libraries depending on the newer SCRAM client in their classpath (e.g., `"org.postgresql" % "r2dbc-postgresql" % "1.1.1.RELEASE"`). The internal `authenticationSASL` code has been refactored to support the 3.x builder API.