### PR TITLE
Update Skunk documentation for release status

### DIFF
--- a/modules/docs/src/main/laika/index.md
+++ b/modules/docs/src/main/laika/index.md
@@ -7,9 +7,8 @@
 - Skunk is purely functional, non-blocking, and provides a tagless-final API.
 - Skunk gives very good error messages.
 - Skunk embraces the [Scala Code of Conduct](http://scala-lang.org/conduct.html).
-- **Skunk is pre-release software!** Code and documentation are under active development!
 
-Skunk is published for Scala 2.12, 2.13, and 3 on JVM, Node.js, and Native. It can be included in your project thus:
+Skunk is published for Scala 2.13, and 3 on JVM, Node.js, and Native. It can be included in your project thus:
 
 ```scala
 libraryDependencies += "org.tpolecat" %% "skunk-core" % "@VERSION@"


### PR DESCRIPTION
Skunk 1.0.0 has been released and dropped support for Scala 2.12.  This updates the microsite to reflect this. 