### PR TITLE
Fix typo in timestamptz precision error message

### DIFF
--- a/modules/core/shared/src/main/scala/codec/TemporalCodecs.scala
+++ b/modules/core/shared/src/main/scala/codec/TemporalCodecs.scala
@@ -138,7 +138,7 @@ trait TemporalCodecs {
     if (precision >= 0 && precision <= 6)
       temporal(offsetDateTimeFormatter(precision), OffsetDateTime.parse, Type.timestamptz(precision))
     else
-      throw new IllegalArgumentException(s"timestampz($precision): invalid precision, expected 0-6")
+      throw new IllegalArgumentException(s"timestamptz($precision): invalid precision, expected 0-6")
 
   private def intervalCodec(tpe: Type): Codec[Duration] =
     Codec.simple(


### PR DESCRIPTION
Fixes #1295.

The `IllegalArgumentException` thrown by `timestamptz(precision)` when given an out-of-range precision misspelled the type name as `timestampz` (missing the `t` before `z`). All other temporal codecs in the same file (`time`, `timetz`, `timestamp`, `interval`) use their correct names in the corresponding error messages, so this aligns `timestamptz` with that convention and with the actual codec function name.

One-character change to a non-asserted exception message in `modules/core/shared/src/main/scala/codec/TemporalCodecs.scala`. No tests reference this string.