### PR TITLE
Add new completion cases for `SERVER` & `USER MAPPING`

### DIFF
--- a/modules/core/shared/src/main/scala/data/Completion.scala
+++ b/modules/core/shared/src/main/scala/data/Completion.scala
@@ -67,7 +67,7 @@ object Completion {
   case object Grant                     extends Completion
   case object Revoke                    extends Completion
   case object AlterIndex                extends Completion
-  case class Merge(count: Int)          extends Completion
+  case class  Merge(count: Int)         extends Completion
   case object CreatePolicy              extends Completion
   case object AlterPolicy               extends Completion
   case object DropPolicy                extends Completion
@@ -76,6 +76,12 @@ object Completion {
   case object AlterDefaultPrivileges    extends Completion
   case object GrantRole                 extends Completion
   case object RevokeRole                extends Completion
+  case object CreateServer              extends Completion
+  case object AlterServer               extends Completion
+  case object DropServer                extends Completion
+  case object CreateUserMapping         extends Completion
+  case object AlterUserMapping          extends Completion
+  case object DropUserMapping           extends Completion
 
   // more ...
 

--- a/modules/core/shared/src/main/scala/net/message/CommandComplete.scala
+++ b/modules/core/shared/src/main/scala/net/message/CommandComplete.scala
@@ -115,6 +115,12 @@ object CommandComplete {
     case "ALTER DEFAULT PRIVILEGES"   => apply(Completion.AlterDefaultPrivileges)
     case "GRANT ROLE"                 => apply(Completion.GrantRole)
     case "REVOKE ROLE"                => apply(Completion.RevokeRole)
+    case "CREATE SERVER"              => apply(Completion.CreateServer)
+    case "ALTER SERVER"               => apply(Completion.AlterServer)
+    case "DROP SERVER"                => apply(Completion.DropServer)
+    case "CREATE USER MAPPING"        => apply(Completion.CreateUserMapping)
+    case "ALTER USER MAPPING"         => apply(Completion.AlterUserMapping)
+    case "DROP USER MAPPING"          => apply(Completion.DropUserMapping)
     // more .. fill in as we hit them
 
     // weird Redshift variations

--- a/modules/tests/shared/src/test/scala/CommandTest.scala
+++ b/modules/tests/shared/src/test/scala/CommandTest.scala
@@ -379,6 +379,24 @@ class CommandTest extends SkunkTest {
   val analyzeVerbose: Command[Void] =
     sql"ANALYZE VERBOSE city".command
 
+  val createServer: Command[Void] =
+    sql"CREATE SERVER my_server FOREIGN DATA WRAPPER postgres_fdw".command
+
+  val alterServer: Command[Void] =
+    sql"ALTER SERVER my_server OPTIONS (ADD host 'example.com')".command
+
+  val dropServer: Command[Void] =
+    sql"DROP SERVER my_server".command
+
+  val createUserMapping: Command[Void] =
+    sql"CREATE USER MAPPING FOR skunk_role SERVER my_server".command
+
+  val alterUserMapping: Command[Void] =
+    sql"ALTER USER MAPPING FOR skunk_role SERVER my_server OPTIONS (ADD password_required 'false')".command
+
+  val dropUserMapping: Command[Void] =
+    sql"DROP USER MAPPING FOR skunk_role SERVER my_server".command
+
   private implicit val eq: Eq[Completion] = Eq.fromUniversalEquals
 
   sessionTest("create table, create index, alter table, alter index, drop index and drop table") { s =>
@@ -700,4 +718,26 @@ class CommandTest extends SkunkTest {
     } yield "ok"
   }
 
+  sessionTest("create, alter and drop server, user mapping") { s =>
+    for {
+      _ <- s.execute(sql"CREATE EXTENSION IF NOT EXISTS postgres_fdw".command)
+
+      c <- s.execute(createServer)
+      _ <- assertEqual("completion", c, Completion.CreateServer)
+      c <- s.execute(alterServer)
+      _ <- assertEqual("completion", c, Completion.AlterServer)
+
+      _ <- s.execute(createRole)
+      c <- s.execute(createUserMapping)
+      _ <- assertEqual("completion", c, Completion.CreateUserMapping)
+      c <- s.execute(alterUserMapping)
+      _ <- assertEqual("completion", c, Completion.AlterUserMapping)
+      c <- s.execute(dropUserMapping)
+      _ <- assertEqual("completion", c, Completion.DropUserMapping)
+      _ <- s.execute(dropRole)
+
+      c <- s.execute(dropServer)
+      _ <- assertEqual("completion", c, Completion.DropServer)
+    } yield "ok"
+  }
 }

--- a/modules/tests/shared/src/test/scala/CommandTest.scala
+++ b/modules/tests/shared/src/test/scala/CommandTest.scala
@@ -392,7 +392,7 @@ class CommandTest extends SkunkTest {
     sql"CREATE USER MAPPING FOR skunk_role SERVER my_server".command
 
   val alterUserMapping: Command[Void] =
-    sql"ALTER USER MAPPING FOR skunk_role SERVER my_server OPTIONS (ADD password_required 'false')".command
+    sql"ALTER USER MAPPING FOR skunk_role SERVER my_server OPTIONS (ADD user 'test_user')".command
 
   val dropUserMapping: Command[Void] =
     sql"DROP USER MAPPING FOR skunk_role SERVER my_server".command
@@ -719,25 +719,31 @@ class CommandTest extends SkunkTest {
   }
 
   sessionTest("create, alter and drop server, user mapping") { s =>
-    for {
-      _ <- s.execute(sql"CREATE EXTENSION IF NOT EXISTS postgres_fdw".command)
+    s.unique(sql"SHOW server_version".query(skunk.codec.all.text))
+      .flatMap { version =>
+        val majorVersion = version.substring(0, 2).toInt
+        if (majorVersion >= 13) {
+          for {
+            _ <- s.execute(sql"CREATE EXTENSION IF NOT EXISTS postgres_fdw".command)
 
-      c <- s.execute(createServer)
-      _ <- assertEqual("completion", c, Completion.CreateServer)
-      c <- s.execute(alterServer)
-      _ <- assertEqual("completion", c, Completion.AlterServer)
+            c <- s.execute(createServer)
+            _ <- assertEqual("completion", c, Completion.CreateServer)
+            c <- s.execute(alterServer)
+            _ <- assertEqual("completion", c, Completion.AlterServer)
 
-      _ <- s.execute(createRole)
-      c <- s.execute(createUserMapping)
-      _ <- assertEqual("completion", c, Completion.CreateUserMapping)
-      c <- s.execute(alterUserMapping)
-      _ <- assertEqual("completion", c, Completion.AlterUserMapping)
-      c <- s.execute(dropUserMapping)
-      _ <- assertEqual("completion", c, Completion.DropUserMapping)
-      _ <- s.execute(dropRole)
+            _ <- s.execute(createRole)
+            c <- s.execute(createUserMapping)
+            _ <- assertEqual("completion", c, Completion.CreateUserMapping)
+            c <- s.execute(alterUserMapping)
+            _ <- assertEqual("completion", c, Completion.AlterUserMapping)
+            c <- s.execute(dropUserMapping)
+            _ <- assertEqual("completion", c, Completion.DropUserMapping)
+            _ <- s.execute(dropRole)
 
-      c <- s.execute(dropServer)
-      _ <- assertEqual("completion", c, Completion.DropServer)
-    } yield "ok"
+            c <- s.execute(dropServer)
+            _ <- assertEqual("completion", c, Completion.DropServer)
+          } yield "ok"
+        } else IO.pure("skip")
+      }
   }
 }


### PR DESCRIPTION
This change adds support for foreign data wrapper _(FDW)_ related commands. It introduces new Completion cases for `CREATE`/`ALTER`/`DROP SERVER` and `CREATE`/`ALTER`/`DROP USER MAPPING`. The `CommandComplete` message handling is updated to recognize these new completion tags from PostgreSQL. A few new test case have been added to verify the execution of these FDW commands.